### PR TITLE
Rclone skip check

### DIFF
--- a/migrations/Version20260508014307.php
+++ b/migrations/Version20260508014307.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260508014307 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE backup_configuration ADD skip_rclone_check BOOLEAN DEFAULT false NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE backup_configuration DROP skip_rclone_check');
+    }
+}

--- a/src/Controller/Admin/BackupConfigurationCrudController.php
+++ b/src/Controller/Admin/BackupConfigurationCrudController.php
@@ -126,6 +126,11 @@ class BackupConfigurationCrudController extends AbstractCrudController
                 ->hideOnIndex()
                 ->addCssClass('backupConfigurationType-field rclone')
                 ->setHelp('Additional flags to pass to rclone sync command (--verbose, --ignore-errors, ...)'),
+            BooleanField::new('skipRcloneCheck')
+                ->hideOnIndex()
+                ->renderAsSwitch(false)
+                ->addCssClass('backupConfigurationType-field rclone')
+                ->setHelp('Skip rclone check/cryptcheck during health check. Size verification (rclone size + minimum size) still runs.'),
             TextField::new('resticCheckTags')
                 ->hideOnIndex()
                 ->addCssClass(\sprintf('backupConfigurationType-field %s', BackupConfiguration::TYPE_READ_RESTIC))

--- a/src/Entity/BackupConfiguration.php
+++ b/src/Entity/BackupConfiguration.php
@@ -110,6 +110,9 @@ class BackupConfiguration implements Stringable
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $rcloneConfiguration = null;
 
+    #[ORM\Column(type: Types::BOOLEAN, options: ['default' => false])]
+    private bool $skipRcloneCheck = false;
+
     #[ORM\Column(type: Types::SMALLINT, options: ['default' => 1])]
     private int $notifyEvery = 1;
 
@@ -516,6 +519,18 @@ class BackupConfiguration implements Stringable
     public function setRcloneFlags(?string $rcloneFlags): self
     {
         $this->rcloneFlags = $rcloneFlags;
+
+        return $this;
+    }
+
+    public function isSkipRcloneCheck(): bool
+    {
+        return $this->skipRcloneCheck;
+    }
+
+    public function setSkipRcloneCheck(bool $skipRcloneCheck): self
+    {
+        $this->skipRcloneCheck = $skipRcloneCheck;
 
         return $this;
     }

--- a/src/Service/BackupService.php
+++ b/src/Service/BackupService.php
@@ -1259,27 +1259,31 @@ class BackupService
                 $filesystem->appendToFile($configFile, $backup->getBackupConfiguration()->getCompleteRcloneConfiguration());
                 $env = $backup->getBackupConfiguration()->getStorage()->getEnv() + $backup->getBackupConfiguration()->getResticEnv();
 
-                $isCrypt = preg_match('/^\s*type\s*=\s*crypt\s*$/m', (string) $backup->getBackupConfiguration()->getCompleteRcloneConfiguration());
-
-                $command = 'rclone "${CHECK}" "${SOURCE_LOCATION}" "${REMOTE_STORAGE_LOCATION}" --config "${RCLONE_CONFIG}"';
-                $parameters = [
-                    'CHECK' => $isCrypt ? 'cryptcheck' : 'check',
-                    'SOURCE_LOCATION' => $backup->getBackupConfiguration()->getRemotePath(),
-                    'REMOTE_STORAGE_LOCATION' => $backup->getBackupConfiguration()->getStorageSubPath(),
-                    'RCLONE_CONFIG' => $configFile,
-                ];
-
-                $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, nl2br($this->logParameters($parameters))));
-                $process = Process::fromShellCommandline($command, null, $parameters);
-
-                $process->setTimeout(self::RCLONE_CHECK_TIMEOUT);
-                $process->run();
-
-                if (!$process->isSuccessful()) {
-                    $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $process->getErrorOutput()));
-                    throw new ProcessFailedException($process);
+                if ($backup->getBackupConfiguration()->isSkipRcloneCheck()) {
+                    $this->log($backup, Log::LOG_NOTICE, 'Skipping rclone check (skipRcloneCheck enabled on configuration)');
                 } else {
-                    $this->log($backup, Log::LOG_INFO, $process->getOutput());
+                    $isCrypt = preg_match('/^\s*type\s*=\s*crypt\s*$/m', (string) $backup->getBackupConfiguration()->getCompleteRcloneConfiguration());
+
+                    $command = 'rclone "${CHECK}" "${SOURCE_LOCATION}" "${REMOTE_STORAGE_LOCATION}" --config "${RCLONE_CONFIG}"';
+                    $parameters = [
+                        'CHECK' => $isCrypt ? 'cryptcheck' : 'check',
+                        'SOURCE_LOCATION' => $backup->getBackupConfiguration()->getRemotePath(),
+                        'REMOTE_STORAGE_LOCATION' => $backup->getBackupConfiguration()->getStorageSubPath(),
+                        'RCLONE_CONFIG' => $configFile,
+                    ];
+
+                    $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, nl2br($this->logParameters($parameters))));
+                    $process = Process::fromShellCommandline($command, null, $parameters);
+
+                    $process->setTimeout(self::RCLONE_CHECK_TIMEOUT);
+                    $process->run();
+
+                    if (!$process->isSuccessful()) {
+                        $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $process->getErrorOutput()));
+                        throw new ProcessFailedException($process);
+                    } else {
+                        $this->log($backup, Log::LOG_INFO, $process->getOutput());
+                    }
                 }
 
                 $command = 'rclone size "${REMOTE_STORAGE_LOCATION}" --config "${RCLONE_CONFIG}" --json';

--- a/tests/Entity/BackupConfigurationTest.php
+++ b/tests/Entity/BackupConfigurationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\BackupConfiguration;
+use PHPUnit\Framework\TestCase;
+
+final class BackupConfigurationTest extends TestCase
+{
+    public function testSkipRcloneCheckDefaultsToFalse(): void
+    {
+        $config = new BackupConfiguration();
+
+        self::assertFalse($config->isSkipRcloneCheck());
+    }
+
+    public function testSkipRcloneCheckSetterReturnsSelfAndPersistsValue(): void
+    {
+        $config = new BackupConfiguration();
+
+        $result = $config->setSkipRcloneCheck(true);
+
+        self::assertSame($config, $result);
+        self::assertTrue($config->isSkipRcloneCheck());
+
+        $config->setSkipRcloneCheck(false);
+        self::assertFalse($config->isSkipRcloneCheck());
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added option to skip rclone checks during health checks while maintaining size verification.
  * New configuration toggle in backup settings allows users to control rclone verification behavior.

* **Tests**
  * Added test coverage for the new skip rclone check functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->