### PR TITLE
chore(githooks): add pre-commit and commit-msg hooks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Commit-msg hook: enforce Conventional Commits on the subject line.
+#   <type>[optional scope][!]: <description>
+# Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert.
+# Optional scope: (lowercase letters, digits, '_' or '-').
+# Optional '!' marks a breaking change.
+# Subject length: 1-100 chars (Git's display soft-limit is 72; we allow a little slack).
+
+set -euo pipefail
+
+msg_file="$1"
+subject=$(grep -m1 -v '^\s*#' "${msg_file}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' || true)
+
+# Bypass cases — let Git's own machinery through.
+case "${subject}" in
+    "")                          exit 0 ;;  # empty (commit will abort anyway)
+    "Merge "*|"Revert "*)        exit 0 ;;  # merge / revert auto-messages
+    "fixup! "*|"squash! "*|"amend! "*) exit 0 ;;  # rebase --autosquash markers
+esac
+
+pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9_/-]+\))?!?: .{1,100}$'
+
+if ! [[ "${subject}" =~ ${pattern} ]]; then
+    cat >&2 <<EOF
+[commit-msg] Commit subject does not follow Conventional Commits.
+
+Got:
+    ${subject}
+
+Expected:
+    <type>[(scope)][!]: <subject>
+
+Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+Examples:
+    feat(backup): add upper-bound size guard
+    fix(auth): null-check user before email read
+    refactor!: drop deprecated v1 endpoints
+
+See https://www.conventionalcommits.org/ for details.
+EOF
+    exit 1
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Pre-commit hook: php-cs-fixer fix, phpstan analyse, rector --dry-run
+# Runs inside the project's PHP container (per project convention).
+#   - If executed from inside a container: run tools directly.
+#   - If executed on the host: route through `docker compose exec php`.
+# Skips silently when neither path is usable.
+
+set -euo pipefail
+
+SERVICE=php
+
+STAGED=()
+while IFS= read -r line; do
+    [ -n "${line}" ] && STAGED+=("${line}")
+done < <(git diff --cached --name-only --diff-filter=ACMR -- '*.php')
+
+if [ ${#STAGED[@]} -eq 0 ]; then
+    exit 0
+fi
+
+# Detect "are we already inside a container?" — /.dockerenv exists in every
+# container started by docker/podman.
+if [ -f /.dockerenv ]; then
+    runner=(env)
+else
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "[pre-commit] docker not found, skipping PHP checks" >&2
+        exit 0
+    fi
+    if docker compose ps --services --filter status=running 2>/dev/null | grep -qx "${SERVICE}"; then
+        # Service running — attach (fast, warm caches).
+        runner=(docker compose exec -T "${SERVICE}")
+    else
+        # Service down — spawn ephemeral container, no deps, auto-remove.
+        echo "[pre-commit] '${SERVICE}' service not running, falling back to 'docker compose run'" >&2
+        runner=(docker compose run --rm --no-deps -T "${SERVICE}")
+    fi
+fi
+
+run() { "${runner[@]}" "$@"; }
+
+echo "[pre-commit] php-cs-fixer fix (${#STAGED[@]} file(s))"
+run vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --using-cache=no -- "${STAGED[@]}"
+
+# Re-stage files that php-cs-fixer may have rewritten.
+git add -- "${STAGED[@]}"
+
+echo "[pre-commit] phpstan analyse"
+run vendor/bin/phpstan analyse --configuration=phpstan.neon.dist --no-progress --memory-limit=1G -- "${STAGED[@]}"
+
+echo "[pre-commit] rector --dry-run"
+run vendor/bin/rector process --dry-run --no-progress-bar -- "${STAGED[@]}"
+
+echo "[pre-commit] ok"

--- a/composer.json
+++ b/composer.json
@@ -103,11 +103,14 @@
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
         },
+        "set-hooks-path": "[ -d .git ] && git config core.hooksPath .githooks || true",
         "post-install-cmd": [
-            "@auto-scripts"
+            "@auto-scripts",
+            "@set-hooks-path"
         ],
         "post-update-cmd": [
-            "@auto-scripts"
+            "@auto-scripts",
+            "@set-hooks-path"
         ],
         "workflow-dump": "php bin/console workflow:dump backup | dot -Tsvg -o doc/graph.svg"
     },


### PR DESCRIPTION
  Add a versioned `.githooks/` directory with two hooks:

    - pre-commit: runs php-cs-fixer (fix), phpstan (analyse) and
      rector (--dry-run) against staged PHP files. Detects whether
      it executes inside a container and routes commands through
      `docker compose exec php` when the service is running, falling
      back to `docker compose run --rm --no-deps -T php` otherwise.

    - commit-msg: enforces the Conventional Commits format on the
      commit subject and prints a guidance block on failure. Bypasses
      merge/revert/fixup auto-messages.

  Wire `core.hooksPath` to `.githooks` automatically via a new
  composer `set-hooks-path` script chained into `post-install-cmd`
  and `post-update-cmd`, so every clone activates the hooks after
  the next `composer install`.