### PR TITLE
feat(kopia): add monitoring-only Kopia backup support

### DIFF
--- a/docker/frankenphp/Dockerfile
+++ b/docker/frankenphp/Dockerfile
@@ -62,6 +62,14 @@ RUN wget --quiet "https://github.com/restic/restic/releases/download/v${RESTIC_V
     && mv "restic_${RESTIC_VERSION}_linux_amd64" /usr/local/bin/restic \
     && chmod +x /usr/local/bin/restic
 
+ARG KOPIA_VERSION=0.22.3
+RUN curl -fsSL "https://github.com/kopia/kopia/releases/download/v${KOPIA_VERSION}/kopia-${KOPIA_VERSION}-linux-x64.tar.gz" \
+        -o /tmp/kopia.tar.gz \
+    && tar -xzf /tmp/kopia.tar.gz -C /tmp \
+    && mv "/tmp/kopia-${KOPIA_VERSION}-linux-x64/kopia" /usr/local/bin/kopia \
+    && chmod +x /usr/local/bin/kopia \
+    && rm -rf /tmp/kopia.tar.gz "/tmp/kopia-${KOPIA_VERSION}-linux-x64"
+
 RUN install-php-extensions \
 	pdo_pgsql \
 	gd \

--- a/fixtures/dev/fixtures.yaml
+++ b/fixtures/dev/fixtures.yaml
@@ -65,6 +65,12 @@ App\Entity\Storage:
             remote = repo:rclone-bucket/subdirectory
             password = egtBWMUKof2xAPP_jYBrMu1VA4c
             password2 = 7B_ZxzkfP6Q0ObYu5eWPDUnztoA
+    kopia:
+        name: kopia
+        type: kopia
+        kopiaBackend: s3
+        kopiaConnectArgs: '--access-key=minioadmin --secret-access-key=minioadmin --bucket=kopia --endpoint=minio:9000 --disable-tls --prefix=repo/'
+        kopiaPassword: kopiaPassword
 
 App\Entity\Host:
     host-by-key:
@@ -203,6 +209,17 @@ App\Entity\BackupConfiguration:
         keepWeekly: 4
         storage: "@swift"
         storageSubPath: "daily-mysql-host-pass"
+        enabled: false
+    read-kopia:
+        name: read-kopia
+        type: read-kopia
+        periodicity: "daily"
+        keepDaily: 7
+        keepWeekly: 4
+        storage: "@kopia"
+        storageSubPath: "daily-read-kopia"
+        kopiaCheckTags: ~
+        minimumBackupSize: 1024
         enabled: false
     ssh-cmd:
         name: daily-ssh-cmd

--- a/migrations/Version20260511002700.php
+++ b/migrations/Version20260511002700.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260511002700 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add Kopia storage / backup-configuration / backup columns for monitoring-only Kopia support.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE storage ADD kopia_backend VARCHAR(32) DEFAULT NULL');
+        $this->addSql('ALTER TABLE storage ADD kopia_connect_args TEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE storage ADD kopia_password VARCHAR(255) DEFAULT NULL');
+
+        $this->addSql('ALTER TABLE backup_configuration ADD kopia_check_tags VARCHAR(255) DEFAULT NULL');
+
+        $this->addSql('ALTER TABLE backup ADD kopia_size BIGINT DEFAULT NULL');
+        $this->addSql('ALTER TABLE backup ADD kopia_total_size BIGINT DEFAULT NULL');
+        $this->addSql('ALTER TABLE backup ADD kopia_total_dedup_size BIGINT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE backup DROP kopia_total_dedup_size');
+        $this->addSql('ALTER TABLE backup DROP kopia_total_size');
+        $this->addSql('ALTER TABLE backup DROP kopia_size');
+
+        $this->addSql('ALTER TABLE backup_configuration DROP kopia_check_tags');
+
+        $this->addSql('ALTER TABLE storage DROP kopia_password');
+        $this->addSql('ALTER TABLE storage DROP kopia_connect_args');
+        $this->addSql('ALTER TABLE storage DROP kopia_backend');
+    }
+}

--- a/src/Controller/Admin/BackupConfigurationCrudController.php
+++ b/src/Controller/Admin/BackupConfigurationCrudController.php
@@ -135,6 +135,17 @@ class BackupConfigurationCrudController extends AbstractCrudController
                 ->hideOnIndex()
                 ->addCssClass(\sprintf('backupConfigurationType-field %s', BackupConfiguration::TYPE_READ_RESTIC))
                 ->setHelp('Filter restic snapshot with provided tags. Usefull to check specific Velero volume'),
+            TextField::new('kopiaCheckTags')
+                ->hideOnIndex()
+                ->addCssClass(\sprintf('backupConfigurationType-field %s', BackupConfiguration::TYPE_READ_KOPIA))
+                ->setHelp(
+                    'Filter kopia snapshots by tag.<br />'
+                    .'Format: one or more <code>key:value</code> pairs separated by spaces.<br />'
+                    .'Examples:<br />'
+                    .'<code>workload:db</code> &mdash; single tag<br />'
+                    .'<code>workload:db env:prod</code> &mdash; multiple tags (AND filter; snapshot must carry every listed pair)<br />'
+                    .'Leave empty to monitor all snapshots in the repository.'
+                ),
 
             AssociationField::new('kubeconfig')
                 ->setRequired(false)

--- a/src/Controller/Admin/BackupCrudController.php
+++ b/src/Controller/Admin/BackupCrudController.php
@@ -111,6 +111,20 @@ class BackupCrudController extends AbstractCrudController
                 ->setTemplatePath('admin/fields/humanizedFilesize.html.twig')
                 ->hideOnIndex()
                 ->hideOnForm(),
+            IntegerField::new('kopiaSize')
+                ->setLabel('Kopia snapshot size')
+                ->setTemplatePath('admin/fields/humanizedFilesize.html.twig')
+                ->hideOnForm(),
+            IntegerField::new('kopiaTotalSize')
+                ->setLabel('Kopia total size')
+                ->setTemplatePath('admin/fields/humanizedFilesize.html.twig')
+                ->hideOnIndex()
+                ->hideOnForm(),
+            IntegerField::new('kopiaTotalDedupSize')
+                ->setLabel('Kopia total deduplicated size')
+                ->setTemplatePath('admin/fields/humanizedFilesize.html.twig')
+                ->hideOnIndex()
+                ->hideOnForm(),
             AssociationField::new('logs')->hideOnForm(),
             DateTimeField::new('createdAt')->hideOnForm(),
             DateTimeField::new('updatedAt')->hideOnForm(),

--- a/src/Controller/Admin/StorageCrudController.php
+++ b/src/Controller/Admin/StorageCrudController.php
@@ -94,6 +94,13 @@ class StorageCrudController extends AbstractCrudController
             TextareaField::new('rcloneConfiguration')
                 ->hideOnIndex()
                 ->setHelp('See <a href="https://rclone.org/docs/">https://rclone.org/docs/</a> and paste your configuration here.<br />Must not contain password and password2, we will add them automatically from password and salt fields.'),
+            FormField::addFieldset('Kopia configuration')->addCssClass('storage-type-panel type-kopia'),
+            TextField::new('kopiaBackend')
+                ->setHelp('Kopia backend kind, e.g. <code>s3</code>, <code>gcs</code>, <code>b2</code>, <code>sftp</code>, <code>filesystem</code>.'),
+            TextareaField::new('kopiaConnectArgs')
+                ->hideOnIndex()
+                ->setHelp('Verbatim arguments appended after <code>kopia repository connect &lt;backend&gt;</code>.<br />Example: <code>--access-key=AK --secret-access-key=SAK --bucket=mybucket --endpoint=minio:9000 --prefix=repo/</code>'),
+            TextField::new('kopiaPassword')->hideOnIndex(),
         ];
     }
 

--- a/src/Entity/Backup.php
+++ b/src/Entity/Backup.php
@@ -54,6 +54,15 @@ class Backup implements Stringable
     #[ORM\Column(type: Types::BIGINT, nullable: true)]
     private ?int $resticTotalDedupSize = null;
 
+    #[ORM\Column(type: Types::BIGINT, nullable: true)]
+    private ?int $kopiaSize = null;
+
+    #[ORM\Column(type: Types::BIGINT, nullable: true)]
+    private ?int $kopiaTotalSize = null;
+
+    #[ORM\Column(type: Types::BIGINT, nullable: true)]
+    private ?int $kopiaTotalDedupSize = null;
+
     final public const array BOOTSTRAP_COLOR = [
         'dump' => 'info',
         'backuped' => 'success',
@@ -246,6 +255,42 @@ class Backup implements Stringable
     public function setResticTotalDedupSize(?int $resticTotalDedupSize): self
     {
         $this->resticTotalDedupSize = $resticTotalDedupSize;
+
+        return $this;
+    }
+
+    public function getKopiaSize(): ?int
+    {
+        return $this->kopiaSize;
+    }
+
+    public function setKopiaSize(?int $kopiaSize): self
+    {
+        $this->kopiaSize = $kopiaSize;
+
+        return $this;
+    }
+
+    public function getKopiaTotalSize(): ?int
+    {
+        return $this->kopiaTotalSize;
+    }
+
+    public function setKopiaTotalSize(?int $kopiaTotalSize): self
+    {
+        $this->kopiaTotalSize = $kopiaTotalSize;
+
+        return $this;
+    }
+
+    public function getKopiaTotalDedupSize(): ?int
+    {
+        return $this->kopiaTotalDedupSize;
+    }
+
+    public function setKopiaTotalDedupSize(?int $kopiaTotalDedupSize): self
+    {
+        $this->kopiaTotalDedupSize = $kopiaTotalDedupSize;
 
         return $this;
     }

--- a/src/Entity/BackupConfiguration.php
+++ b/src/Entity/BackupConfiguration.php
@@ -83,6 +83,9 @@ class BackupConfiguration implements Stringable
     #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
     private ?string $resticCheckTags = null;
 
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $kopiaCheckTags = null;
+
     #[ORM\ManyToOne(targetEntity: Kubeconfig::class, inversedBy: 'backupConfigurations')]
     private ?Kubeconfig $kubeconfig = null;
 
@@ -125,6 +128,7 @@ class BackupConfiguration implements Stringable
     final public const string TYPE_SSHFS = 'sshfs';
     final public const string TYPE_SSH_RESTIC = 'ssh-restic';
     final public const string TYPE_READ_RESTIC = 'read-restic';
+    final public const string TYPE_READ_KOPIA = 'read-kopia';
     final public const string TYPE_SSH_CMD = 'ssh-cmd';
     final public const string TYPE_SFTP = 'sftp';
     final public const string TYPE_RCLONE = 'rclone';
@@ -182,6 +186,7 @@ class BackupConfiguration implements Stringable
             self::TYPE_SSHFS,
             self::TYPE_SSH_RESTIC,
             self::TYPE_READ_RESTIC,
+            self::TYPE_READ_KOPIA,
             self::TYPE_SSH_CMD,
             self::TYPE_SFTP,
             self::TYPE_RCLONE,
@@ -237,6 +242,20 @@ class BackupConfiguration implements Stringable
         return [
             'RESTIC_PASSWORD' => $this->getStorage()->getResticPassword(),
             'RESTIC_REPOSITORY' => \sprintf('%s/%s', rtrim($this->getStorage()->getResticRepo(), '/'), trim((string) $this->getStorageSubPath(), '/')),
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getKopiaEnv(): array
+    {
+        if (null === $this->getStorage() || null === $this->getStorage()->getKopiaPassword()) {
+            return [];
+        }
+
+        return [
+            'KOPIA_PASSWORD' => $this->getStorage()->getKopiaPassword(),
         ];
     }
 
@@ -543,6 +562,18 @@ class BackupConfiguration implements Stringable
     public function setResticCheckTags(?string $resticCheckTags): self
     {
         $this->resticCheckTags = $resticCheckTags;
+
+        return $this;
+    }
+
+    public function getKopiaCheckTags(): ?string
+    {
+        return $this->kopiaCheckTags;
+    }
+
+    public function setKopiaCheckTags(?string $kopiaCheckTags): self
+    {
+        $this->kopiaCheckTags = $kopiaCheckTags;
 
         return $this;
     }

--- a/src/Entity/Storage.php
+++ b/src/Entity/Storage.php
@@ -53,6 +53,15 @@ class Storage implements Stringable
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $rcloneConfiguration = null;
 
+    #[ORM\Column(type: Types::STRING, length: 32, nullable: true)]
+    private ?string $kopiaBackend = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $kopiaConnectArgs = null;
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $kopiaPassword = null;
+
     /**
      * @var Collection<int, BackupConfiguration>
      */
@@ -61,6 +70,7 @@ class Storage implements Stringable
 
     final public const string TYPE_RESTIC = 'restic';
     final public const string TYPE_RCLONE = 'rclone';
+    final public const string TYPE_KOPIA = 'kopia';
 
     public function __construct()
     {
@@ -126,6 +136,7 @@ class Storage implements Stringable
         return [
             self::TYPE_RESTIC,
             self::TYPE_RCLONE,
+            self::TYPE_KOPIA,
         ];
     }
 
@@ -137,6 +148,11 @@ class Storage implements Stringable
     public function isRclone(): bool
     {
         return self::TYPE_RCLONE === $this->getType();
+    }
+
+    public function isKopia(): bool
+    {
+        return self::TYPE_KOPIA === $this->getType();
     }
 
     public function getId(): ?int
@@ -300,6 +316,42 @@ class Storage implements Stringable
     public function setRcloneConfiguration(?string $rcloneConfiguration): self
     {
         $this->rcloneConfiguration = $rcloneConfiguration;
+
+        return $this;
+    }
+
+    public function getKopiaBackend(): ?string
+    {
+        return $this->kopiaBackend;
+    }
+
+    public function setKopiaBackend(?string $kopiaBackend): self
+    {
+        $this->kopiaBackend = $kopiaBackend;
+
+        return $this;
+    }
+
+    public function getKopiaConnectArgs(): ?string
+    {
+        return $this->kopiaConnectArgs;
+    }
+
+    public function setKopiaConnectArgs(?string $kopiaConnectArgs): self
+    {
+        $this->kopiaConnectArgs = $kopiaConnectArgs;
+
+        return $this;
+    }
+
+    public function getKopiaPassword(): ?string
+    {
+        return $this->kopiaPassword;
+    }
+
+    public function setKopiaPassword(?string $kopiaPassword): self
+    {
+        $this->kopiaPassword = $kopiaPassword;
 
         return $this;
     }

--- a/src/Service/BackupService.php
+++ b/src/Service/BackupService.php
@@ -41,6 +41,8 @@ class BackupService
     final public const RCLONE_UPLOAD_TIMEOUT = 3600 * 4;
     final public const int RCLONE_CHECK_TIMEOUT = 3600;
 
+    final public const int KOPIA_CHECK_TIMEOUT = 3600;
+
     final public const int BACKUP_SIZE_MAX_RATIO = 2;
 
     public function __construct(
@@ -1341,6 +1343,159 @@ class BackupService
                     $message = \sprintf('Rclone failed. Backup size %s exceeds %dx the expected size %s. Please update the expected size to a more appropriate value.', StringUtils::humanizeFileSize($output['bytes']), self::BACKUP_SIZE_MAX_RATIO, StringUtils::humanizeFileSize($minimumBackupSize));
                     $this->log($backup, Log::LOG_NOTICE, $message);
                     throw new Exception($message);
+                }
+                break;
+            case Storage::TYPE_KOPIA:
+                $storage = $backup->getBackupConfiguration()->getStorage();
+                $env = $storage->getEnv() + $backup->getBackupConfiguration()->getKopiaEnv();
+
+                $filesystem = new Filesystem();
+                $configFile = $filesystem->tempnam('/tmp', 'kopia_');
+
+                try {
+                    // 1. Connect to the repository (per-call, ephemeral config file).
+                    $command = \sprintf(
+                        'kopia repository connect %s %s --config-file="${KOPIA_CONFIG}"',
+                        escapeshellarg((string) $storage->getKopiaBackend()),
+                        (string) $storage->getKopiaConnectArgs(),
+                    );
+                    $parameters = ['KOPIA_CONFIG' => $configFile];
+
+                    $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
+                    $process = Process::fromShellCommandline($command, null, $env + $parameters);
+                    $process->setTimeout(self::KOPIA_CHECK_TIMEOUT);
+                    $process->run();
+
+                    if (!$process->isSuccessful()) {
+                        $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $process->getErrorOutput()));
+                        throw new ProcessFailedException($process);
+                    }
+
+                    // 2. Integrity verification (manifests + content metadata, no blob fetch).
+                    $command = 'kopia --config-file="${KOPIA_CONFIG}" snapshot verify --verify-files-percent=0';
+                    $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
+                    $process = Process::fromShellCommandline($command, null, $env + $parameters);
+                    $process->setTimeout(self::KOPIA_CHECK_TIMEOUT);
+                    $process->run();
+
+                    if (!$process->isSuccessful()) {
+                        $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $process->getErrorOutput()));
+                        throw new ProcessFailedException($process);
+                    } else {
+                        $this->log($backup, Log::LOG_INFO, $process->getOutput());
+                    }
+
+                    // 3. Snapshot listing and freshness check.
+                    // Kopia's --tags flag is repeatable (one tag per flag, not CSV), so split the
+                    // whitespace-separated config value into one --tags invocation per token.
+                    $tagsClause = '';
+                    $listParameters = $parameters;
+                    $rawTags = trim((string) $backup->getBackupConfiguration()->getKopiaCheckTags());
+                    if ('' !== $rawTags) {
+                        foreach (preg_split('/\s+/', $rawTags) as $idx => $token) {
+                            $key = \sprintf('KOPIA_CHECK_TAG_%d', $idx);
+                            $tagsClause .= \sprintf(' --tags "${%s}"', $key);
+                            $listParameters[$key] = $token;
+                        }
+                    }
+                    $command = 'kopia --config-file="${KOPIA_CONFIG}" snapshot list --json'.$tagsClause;
+
+                    $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($listParameters)));
+                    $process = Process::fromShellCommandline($command, null, $env + $listParameters);
+                    $process->setTimeout(self::KOPIA_CHECK_TIMEOUT);
+                    $process->run();
+
+                    if (!$process->isSuccessful()) {
+                        $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $process->getErrorOutput()));
+                        throw new ProcessFailedException($process);
+                    }
+
+                    $snapshots = json_decode($process->getOutput(), true, 512, \JSON_THROW_ON_ERROR);
+                    if (!\is_array($snapshots) || [] === $snapshots) {
+                        $message = \sprintf('Cannot decode json or empty snapshot list : %s', $process->getOutput());
+                        $this->log($backup, Log::LOG_ERROR, $message);
+                        throw new Exception($message);
+                    }
+
+                    usort($snapshots, static function ($a, $b) {
+                        return new DateTime($b['endTime']) <=> new DateTime($a['endTime']);
+                    });
+
+                    $this->log($backup, Log::LOG_INFO, json_encode($snapshots, \JSON_PRETTY_PRINT));
+
+                    $lastBackup = new DateTime(preg_replace('/(\d+\-\d+\-\d+T\d+:\d+:\d+)\..*/', '$1', (string) $snapshots[0]['endTime']));
+                    $this->log($backup, Log::LOG_NOTICE, \sprintf('Last backup : %s', $lastBackup->format('d/m/Y H:i')));
+
+                    if ($lastBackup < new DateTime('yesterday')) {
+                        $message = 'Last backup older than 24h';
+                        $this->log($backup, Log::LOG_ERROR, $message);
+                        throw new Exception($message);
+                    }
+
+                    $backup->setKopiaSize((int) ($snapshots[0]['stats']['totalSize'] ?? 0));
+                    $backup->setKopiaTotalSize(array_sum(array_map(
+                        static fn (array $snapshot): int => (int) ($snapshot['stats']['totalSize'] ?? 0),
+                        $snapshots,
+                    )));
+                    $this->log($backup, Log::LOG_NOTICE, \sprintf('Stat kopiaSize : %s', StringUtils::humanizeFileSize($backup->getKopiaSize())));
+                    $this->log($backup, Log::LOG_NOTICE, \sprintf('Stat kopiaTotalSize : %s', StringUtils::humanizeFileSize($backup->getKopiaTotalSize())));
+
+                    // 4. Repository on-disk bytes — aggregated by Kopia, no per-blob payload.
+                    $command = 'kopia --config-file="${KOPIA_CONFIG}" repository status --blob-stats --json';
+                    $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
+                    $process = Process::fromShellCommandline($command, null, $env + $parameters);
+                    $process->setTimeout(self::KOPIA_CHECK_TIMEOUT);
+                    $process->run();
+
+                    if (!$process->isSuccessful()) {
+                        $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $process->getErrorOutput()));
+                        throw new ProcessFailedException($process);
+                    }
+
+                    $status = json_decode($process->getOutput(), true, 512, \JSON_THROW_ON_ERROR);
+                    if (!\is_array($status)) {
+                        $message = \sprintf('Cannot decode repository status json : %s', $process->getOutput());
+                        $this->log($backup, Log::LOG_ERROR, $message);
+                        throw new Exception($message);
+                    }
+
+                    // Kopia 0.22 exposes the aggregate under blobStats.totalSize when --blob-stats is on.
+                    // Walk a couple of historical paths so a minor Kopia upgrade doesn't silently zero the metric.
+                    $totalDedup = $status['blobStats']['totalSize']
+                        ?? $status['blobStats']['TotalSize']
+                        ?? $status['BlobStats']['totalSize']
+                        ?? null;
+                    if (null === $totalDedup) {
+                        $message = \sprintf('Cannot read total dedup size from repository status json : %s', $process->getOutput());
+                        $this->log($backup, Log::LOG_ERROR, $message);
+                        throw new Exception($message);
+                    }
+
+                    $backup->setKopiaTotalDedupSize((int) $totalDedup);
+                    $this->log($backup, Log::LOG_NOTICE, \sprintf('Stat kopiaTotalDedupSize : %s', StringUtils::humanizeFileSize($backup->getKopiaTotalDedupSize())));
+
+                    // 5. Default Backup::size to kopiaSize when not already set.
+                    if (null === $backup->getSize()) {
+                        $backup->setSize($backup->getKopiaSize());
+                    }
+
+                    // 6. Min / 2x-max size guards (mirror Restic and Rclone).
+                    $minimumBackupSize = (int) $backup->getBackupConfiguration()->getMinimumBackupSize();
+                    $kopiaSize = (int) $backup->getKopiaSize();
+
+                    if ($kopiaSize <= $minimumBackupSize) {
+                        $message = \sprintf('Kopia failed. Minimum backup size not met : %s < %s', StringUtils::humanizeFileSize($kopiaSize), StringUtils::humanizeFileSize($minimumBackupSize));
+                        $this->log($backup, Log::LOG_NOTICE, $message);
+                        throw new Exception($message);
+                    }
+
+                    if ($minimumBackupSize > 0 && $kopiaSize > self::BACKUP_SIZE_MAX_RATIO * $minimumBackupSize) {
+                        $message = \sprintf('Kopia failed. Backup size %s exceeds %dx the expected size %s. Please update the expected size to a more appropriate value.', StringUtils::humanizeFileSize($kopiaSize), self::BACKUP_SIZE_MAX_RATIO, StringUtils::humanizeFileSize($minimumBackupSize));
+                        $this->log($backup, Log::LOG_NOTICE, $message);
+                        throw new Exception($message);
+                    }
+                } finally {
+                    @unlink($configFile);
                 }
                 break;
         }

--- a/templates/admin/backup/detail.html.twig
+++ b/templates/admin/backup/detail.html.twig
@@ -130,6 +130,83 @@
                 </dl>
             </div>
         </div>
+    {% elseif entity.instance.backupConfiguration.storage.type == 'kopia' %}
+        <h3>
+            Kopia
+        </h3>
+        <div class="content-panel">
+            <div class="content-panel-body without-header without-footer without-padding">
+                <dl class="datalist">
+                    <div class="data-row">
+                        <dd>Help</dd>
+                        <dl>
+                            <a href="https://kopia.io/docs/" target="_blank" rel="noopener noreferrer">
+                                Kopia doc <i class="fas fa-external-link-alt"></i>
+                            </a>
+                        </dl>
+                    </div>
+                    <div class="data-row">
+                        <dd>Connect</dd>
+                        <dl>
+                            <pre class="blur mb-0">
+                                {{- 'kopia repository connect '
+                                    ~ entity.instance.backupConfiguration.storage.kopiaBackend
+                                    ~ ' '
+                                    ~ entity.instance.backupConfiguration.storage.kopiaConnectArgs -}}
+                            </pre>
+                            <small class="text-muted">
+                                Run <code>connect</code> once per workstation. All commands below reuse that local connection state.
+                            </small>
+                        </dl>
+                    </div>
+                    <div class="data-row">
+                        <dd>List snapshots</dd>
+                        <dl>
+                            <pre class="mb-0">
+                                {{- 'kopia snapshot list --json' -}}
+                                {% for tag in (entity.instance.backupConfiguration.kopiaCheckTags|default(''))|split(' ')|filter(t => t != '') %}
+                                    {{- ' --tags ' ~ tag -}}
+                                {% endfor %}
+                            </pre>
+                        </dl>
+
+                        <dd>Mount snapshots read-only</dd>
+                        <dl>
+                            <pre class="mb-0">kopia mount all /mnt/kopia</pre>
+                            <small class="text-muted">
+                                Requires FUSE. Browse host/source/timestamp trees under the mount point.
+                            </small>
+                        </dl>
+
+                        <dd>Restore snapshot in /tmp</dd>
+                        <dl>
+                            <pre class="mb-0">kopia snapshot restore &lt;SNAPSHOT_ID&gt; /tmp/</pre>
+                            <small class="text-muted">
+                                Copy <code>&lt;SNAPSHOT_ID&gt;</code> from the <em>List snapshots</em> output above. Kopia has no <code>latest</code> alias.
+                            </small>
+                        </dl>
+
+                        <dd>Show file from snapshot</dd>
+                        <dl>
+                            <pre class="mb-0">kopia ls &lt;SNAPSHOT_ID&gt;</pre>
+                            <pre class="mb-0">kopia show &lt;OBJECT_ID&gt;</pre>
+                            <small class="text-muted">
+                                <code>ls</code> walks the snapshot tree to find <code>&lt;OBJECT_ID&gt;</code>; <code>show</code> dumps that object's contents on stdout.
+                            </small>
+                        </dl>
+
+                        <dd>Verify integrity</dd>
+                        <dl>
+                            <pre class="mb-0">kopia snapshot verify --verify-files-percent=0</pre>
+                        </dl>
+                        <dd>Repository on-disk stats</dd>
+                        <dl>
+                            <pre class="mb-0">kopia repository status --blob-stats --json</pre>
+                        </dl>
+                    </div>
+                </dl>
+            </div>
+        </div>
     {% endif %}
     <h3>
         Logs

--- a/templates/admin/backup_configuration/detail.html.twig
+++ b/templates/admin/backup_configuration/detail.html.twig
@@ -3,68 +3,160 @@
 {% block main %}
     {{ parent() }}
 
-    <h3>
-        Restic
-    </h3>
-    <div class="content-panel">
-        <div class="content-panel-body without-header without-footer without-padding">
-            <dl class="datalist">
-                <div class="data-row">
-                    <dd>Help</dd>
-                    <dl>
-                        <a href="https://sites.google.com/site/mrxpalmeiras/notes/restic-cheatsheet"
-                            target="_blank">
-                            Restic cheatsheet <i class="fas fa-external-link-alt"></i>
-                        </a>
-                    </dl>
-                </div>
-                <div class="data-row">
-                    <dd>Copy env</dd>
-                    <dl>
-                        <pre class="blur mb-0">
-                            {%- for envName, envValue in entity.instance.storage.env|merge(
-                                entity.instance.resticEnv
-                            ) -%}
-                                export {{ envName }}={{ envValue }}{{ '\n' }}
-                            {%- endfor -%}
-                        </pre>
-                    </dl>
-                </div>
-                <div class="data-row">
-                    <dd>List snapshots</dd>
-                    <dl>
-                        <pre class="mb-0">
-                            restic snapshots
-                        </pre>
-                    </dl>
+    {% if entity.instance.storage.type == 'restic' %}
+        <h3>
+            Restic
+        </h3>
+        <div class="content-panel">
+            <div class="content-panel-body without-header without-footer without-padding">
+                <dl class="datalist">
+                    <div class="data-row">
+                        <dd>Help</dd>
+                        <dl>
+                            <a href="https://sites.google.com/site/mrxpalmeiras/notes/restic-cheatsheet"
+                                target="_blank">
+                                Restic cheatsheet <i class="fas fa-external-link-alt"></i>
+                            </a>
+                        </dl>
+                    </div>
+                    <div class="data-row">
+                        <dd>Copy env</dd>
+                        <dl>
+                            <pre class="blur mb-0">
+                                {%- for envName, envValue in entity.instance.storage.env|merge(
+                                    entity.instance.resticEnv
+                                ) -%}
+                                    export {{ envName }}={{ envValue }}{{ '\n' }}
+                                {%- endfor -%}
+                            </pre>
+                        </dl>
+                    </div>
+                    <div class="data-row">
+                        <dd>List snapshots</dd>
+                        <dl>
+                            <pre class="mb-0">
+                                restic snapshots
+                            </pre>
+                        </dl>
 
-                    <dd>Mount backups on read-only</dd>
-                    <dl>
-                        <pre class="mb-0">
-                            restic mount /mnt/restic
-                        </pre>
-                    </dl>
+                        <dd>Mount backups on read-only</dd>
+                        <dl>
+                            <pre class="mb-0">
+                                restic mount /mnt/restic
+                            </pre>
+                        </dl>
 
-                    <dd>Restore backups in /tmp</dd>
-                    <dl>
-                        <pre class="mb-0">
-                            restic restore latest --target /tmp/
-                        </pre>
-                    </dl>
+                        <dd>Restore backups in /tmp</dd>
+                        <dl>
+                            <pre class="mb-0">
+                                restic restore latest --target /tmp/
+                            </pre>
+                        </dl>
 
-                    <dd>Print last backup on stdin</dd>
-                    <dl>
-                        <pre class="mb-0">
-                            restic snapshots # List snapshots and copy path
-                        </pre>
-                        <pre class="mb-0">
-                            restic dump latest _PATH_
-                        </pre>
-                    </dl>
-                </div>
-            </dl>
+                        <dd>Print last backup on stdin</dd>
+                        <dl>
+                            <pre class="mb-0">
+                                restic snapshots # List snapshots and copy path
+                            </pre>
+                            <pre class="mb-0">
+                                restic dump latest _PATH_
+                            </pre>
+                        </dl>
+                    </div>
+                </dl>
+            </div>
         </div>
-    </div>
+    {% elseif entity.instance.storage.type == 'kopia' %}
+        <h3>
+            Kopia
+        </h3>
+        <div class="content-panel">
+            <div class="content-panel-body without-header without-footer without-padding">
+                <dl class="datalist">
+                    <div class="data-row">
+                        <dd>Help</dd>
+                        <dl>
+                            <a href="https://kopia.io/docs/" target="_blank" rel="noopener noreferrer">
+                                Kopia doc <i class="fas fa-external-link-alt"></i>
+                            </a>
+                        </dl>
+                    </div>
+                    <div class="data-row">
+                        <dd>Copy env</dd>
+                        <dl>
+                            <pre class="blur mb-0">
+                                {%- for envName, envValue in entity.instance.storage.env|merge(
+                                    entity.instance.kopiaEnv
+                                ) -%}
+                                    export {{ envName }}={{ envValue }}{{ '\n' }}
+                                {%- endfor -%}
+                            </pre>
+                        </dl>
+                    </div>
+                    <div class="data-row">
+                        <dd>Connect</dd>
+                        <dl>
+                            <pre class="blur mb-0">
+                                {{- 'kopia repository connect '
+                                    ~ entity.instance.storage.kopiaBackend
+                                    ~ ' '
+                                    ~ entity.instance.storage.kopiaConnectArgs -}}
+                            </pre>
+                            <small class="text-muted">
+                                Run <code>connect</code> once per workstation. All commands below reuse that local connection state.
+                            </small>
+                        </dl>
+                    </div>
+                    <div class="data-row">
+                        <dd>List snapshots</dd>
+                        <dl>
+                            <pre class="mb-0">
+                                {{- 'kopia snapshot list --json' -}}
+                                {% for tag in (entity.instance.kopiaCheckTags|default(''))|split(' ')|filter(t => t != '') %}
+                                    {{- ' --tags ' ~ tag -}}
+                                {% endfor %}
+                            </pre>
+                        </dl>
+
+                        <dd>Mount snapshots read-only</dd>
+                        <dl>
+                            <pre class="mb-0">kopia mount all /mnt/kopia</pre>
+                            <small class="text-muted">
+                                Requires FUSE. Browse host/source/timestamp trees under the mount point.
+                            </small>
+                        </dl>
+
+                        <dd>Restore snapshot in /tmp</dd>
+                        <dl>
+                            <pre class="mb-0">kopia snapshot restore &lt;SNAPSHOT_ID&gt; /tmp/</pre>
+                            <small class="text-muted">
+                                Copy <code>&lt;SNAPSHOT_ID&gt;</code> from the <em>List snapshots</em> output above. Kopia has no <code>latest</code> alias.
+                            </small>
+                        </dl>
+
+                        <dd>Show file from snapshot</dd>
+                        <dl>
+                            <pre class="mb-0">kopia ls &lt;SNAPSHOT_ID&gt;</pre>
+                            <pre class="mb-0">kopia show &lt;OBJECT_ID&gt;</pre>
+                            <small class="text-muted">
+                                <code>ls</code> walks the snapshot tree to find <code>&lt;OBJECT_ID&gt;</code>; <code>show</code> dumps that object's contents on stdout.
+                            </small>
+                        </dl>
+
+                        <dd>Verify integrity</dd>
+                        <dl>
+                            <pre class="mb-0">kopia snapshot verify --verify-files-percent=0</pre>
+                        </dl>
+
+                        <dd>Repository on-disk stats</dd>
+                        <dl>
+                            <pre class="mb-0">kopia repository status --blob-stats --json</pre>
+                        </dl>
+                    </div>
+                </dl>
+            </div>
+        </div>
+    {% endif %}
 
     <h3>
         Backups

--- a/templates/admin/dashboard.html.twig
+++ b/templates/admin/dashboard.html.twig
@@ -58,6 +58,8 @@
                                                                 {% if backupConfiguration.getLastBackup().resticSize|humanizeFileSize != backupConfiguration.getLastBackup().resticDedupSize|humanizeFileSize %}
                                                                     ({{ backupConfiguration.getLastBackup().resticDedupSize|humanizeFileSize }})
                                                                 {% endif %}
+                                                            {% elseif backupConfiguration.getLastBackup().kopiaSize %}
+                                                                : {{ backupConfiguration.getLastBackup().kopiaSize|humanizeFileSize }}
                                                             {% endif %}
                                                         </span>
                                                     </a>
@@ -67,6 +69,11 @@
                                                         {{ backupConfiguration.getLastBackup().resticTotalSize|humanizeFileSize }}
                                                         {% if backupConfiguration.getLastBackup().resticTotalSize|humanizeFileSize != backupConfiguration.getLastBackup().resticTotalDedupSize|humanizeFileSize %}
                                                             (real : {{ backupConfiguration.getLastBackup().resticTotalDedupSize|humanizeFileSize }})
+                                                        {% endif %}
+                                                    {% elseif backupConfiguration.getLastBackup().kopiaTotalSize %}
+                                                        {{ backupConfiguration.getLastBackup().kopiaTotalSize|humanizeFileSize }}
+                                                        {% if backupConfiguration.getLastBackup().kopiaTotalDedupSize and backupConfiguration.getLastBackup().kopiaTotalSize|humanizeFileSize != backupConfiguration.getLastBackup().kopiaTotalDedupSize|humanizeFileSize %}
+                                                            (real : {{ backupConfiguration.getLastBackup().kopiaTotalDedupSize|humanizeFileSize }})
                                                         {% endif %}
                                                     {% elseif backupConfiguration.getLastBackup().size %}
                                                         {{ backupConfiguration.getLastBackup().size|humanizeFileSize }}
@@ -93,12 +100,16 @@
         <div class="tab-pane fade" id="restore" role="tabpanel" aria-labelledby="restore-tab">
             {% set totalSize = 0 %}
             {% for backupConfiguration in backupConfigurations | filter(bc => bc.getLastBackup()) %}
-                {% set totalSize = totalSize + backupConfiguration.getLastBackup().resticSize %}
+                {% set totalSize = totalSize
+                    + (backupConfiguration.getLastBackup().resticSize ?? 0)
+                    + (backupConfiguration.getLastBackup().kopiaSize ?? 0) %}
             {% endfor %}
 
             {% set totalRepositoryUsage = 0 %}
             {% for backupConfiguration in backupConfigurations | filter(bc => bc.getLastBackup()) %}
-                {% set totalRepositoryUsage = totalRepositoryUsage + backupConfiguration.getLastBackup().resticTotalDedupSize %}
+                {% set totalRepositoryUsage = totalRepositoryUsage
+                    + (backupConfiguration.getLastBackup().resticTotalDedupSize ?? 0)
+                    + (backupConfiguration.getLastBackup().kopiaTotalDedupSize ?? 0) %}
             {% endfor %}
 
             <ul class="alert alert-warning mt-2 mb-2 list list-unstyled">
@@ -106,22 +117,48 @@
                 <li>Total repository usage : {{ totalRepositoryUsage|humanizeFileSize }}</li>
                 <li>Backups are restored to /tmp/restore/xxx. Edit it if needed.</li>
             </ul>
-            
+
             {%- for backupConfiguration in backupConfigurations | filter(bc => bc.getLastBackup()) -%}
                 <h3># {{ backupConfiguration.name }} from {{ backupConfiguration.storage.name }}</h3>
-                <p>
-                    # Backup size : {{ backupConfiguration.getLastBackup().resticSize|humanizeFileSize }}.<br />
-                    # Total repository usage: {{ totalRepositoryUsage|humanizeFileSize }}
-                </p>
+                {% if backupConfiguration.storage.type == 'kopia' %}
+                    <p>
+                        # Backup size : {{ backupConfiguration.getLastBackup().kopiaSize|humanizeFileSize }}.<br />
+                        # Total repository usage: {{ backupConfiguration.getLastBackup().kopiaTotalDedupSize|humanizeFileSize }}
+                    </p>
 
-                <pre class="blur mb-0">
-                    {%- for envName, envValue in (backupConfiguration.storage.env | merge(backupConfiguration.resticEnv)) -%}
-                        export {{ envName }}={{ envValue }}{{ "\n" }}
-                    {%- endfor -%}
+                    <pre class="blur mb-0">
+                        {%- for envName, envValue in (backupConfiguration.storage.env | merge(backupConfiguration.kopiaEnv)) -%}
+                            export {{ envName }}={{ envValue }}{{ "\n" }}
+                        {%- endfor -%}
 
-                    {{- 'restic restore latest --target /tmp/restore/' ~ backupConfiguration.slug -}}
+                        {{- 'kopia repository connect '
+                            ~ backupConfiguration.storage.kopiaBackend
+                            ~ ' '
+                            ~ backupConfiguration.storage.kopiaConnectArgs -}}{{ "\n" }}
 
-                </pre>
+                        {{- '# pick <SNAPSHOT_ID> from this list:' }}{{ "\n" }}
+                        {{- 'kopia snapshot list --json' -}}
+                        {% for tag in (backupConfiguration.kopiaCheckTags|default(''))|split(' ')|filter(t => t != '') %}
+                            {{- ' --tags ' ~ tag -}}
+                        {% endfor %}{{ "\n" }}
+
+                        {{- 'kopia snapshot restore <SNAPSHOT_ID> /tmp/restore/' ~ backupConfiguration.slug -}}
+                    </pre>
+                {% else %}
+                    <p>
+                        # Backup size : {{ backupConfiguration.getLastBackup().resticSize|humanizeFileSize }}.<br />
+                        # Total repository usage: {{ totalRepositoryUsage|humanizeFileSize }}
+                    </p>
+
+                    <pre class="blur mb-0">
+                        {%- for envName, envValue in (backupConfiguration.storage.env | merge(backupConfiguration.resticEnv)) -%}
+                            export {{ envName }}={{ envValue }}{{ "\n" }}
+                        {%- endfor -%}
+
+                        {{- 'restic restore latest --target /tmp/restore/' ~ backupConfiguration.slug -}}
+
+                    </pre>
+                {% endif %}
             {%- endfor -%}
         </div>
         <div class="tab-pane fade" id="inventory" role="tabpanel" aria-labelledby="inventory-tab">

--- a/tests/Entity/BackupConfigurationTest.php
+++ b/tests/Entity/BackupConfigurationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Entity;
 
 use App\Entity\BackupConfiguration;
+use App\Entity\Storage;
 use PHPUnit\Framework\TestCase;
 
 final class BackupConfigurationTest extends TestCase
@@ -27,5 +28,50 @@ final class BackupConfigurationTest extends TestCase
 
         $config->setSkipRcloneCheck(false);
         self::assertFalse($config->isSkipRcloneCheck());
+    }
+
+    public function testGetKopiaEnvReturnsExpectedShape(): void
+    {
+        $storage = new Storage()
+            ->setType(Storage::TYPE_KOPIA)
+            ->setKopiaPassword('secret');
+
+        $config = new BackupConfiguration()
+            ->setStorage($storage);
+
+        self::assertSame(['KOPIA_PASSWORD' => 'secret'], $config->getKopiaEnv());
+    }
+
+    public function testGetKopiaEnvReturnsEmptyArrayWhenNoStorage(): void
+    {
+        $config = new BackupConfiguration();
+
+        self::assertSame([], $config->getKopiaEnv());
+    }
+
+    public function testGetKopiaEnvReturnsEmptyArrayWhenPasswordMissing(): void
+    {
+        $storage = new Storage()
+            ->setType(Storage::TYPE_KOPIA);
+
+        $config = new BackupConfiguration()
+            ->setStorage($storage);
+
+        self::assertSame([], $config->getKopiaEnv());
+    }
+
+    public function testKopiaCheckTagsRoundTrip(): void
+    {
+        $config = new BackupConfiguration();
+
+        self::assertNull($config->getKopiaCheckTags());
+
+        $result = $config->setKopiaCheckTags('workload:db');
+
+        self::assertSame($config, $result);
+        self::assertSame('workload:db', $config->getKopiaCheckTags());
+
+        $config->setKopiaCheckTags(null);
+        self::assertNull($config->getKopiaCheckTags());
     }
 }

--- a/tests/Entity/StorageTest.php
+++ b/tests/Entity/StorageTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\Storage;
+use PHPUnit\Framework\TestCase;
+
+final class StorageTest extends TestCase
+{
+    public function testIsKopiaTrueWhenTypeIsKopia(): void
+    {
+        $storage = new Storage()->setType(Storage::TYPE_KOPIA);
+
+        self::assertTrue($storage->isKopia());
+        self::assertFalse($storage->isRestic());
+        self::assertFalse($storage->isRclone());
+    }
+
+    public function testIsKopiaFalseForOtherTypes(): void
+    {
+        $restic = new Storage()->setType(Storage::TYPE_RESTIC);
+        $rclone = new Storage()->setType(Storage::TYPE_RCLONE);
+
+        self::assertFalse($restic->isKopia());
+        self::assertFalse($rclone->isKopia());
+    }
+
+    public function testGetAvailableTypesIncludesKopia(): void
+    {
+        self::assertContains(Storage::TYPE_KOPIA, Storage::getAvailableTypes());
+    }
+
+    public function testKopiaFieldRoundTrip(): void
+    {
+        $storage = new Storage();
+
+        self::assertSame($storage, $storage->setKopiaBackend('s3'));
+        self::assertSame($storage, $storage->setKopiaConnectArgs('--bucket=mybucket'));
+        self::assertSame($storage, $storage->setKopiaPassword('secret'));
+
+        self::assertSame('s3', $storage->getKopiaBackend());
+        self::assertSame('--bucket=mybucket', $storage->getKopiaConnectArgs());
+        self::assertSame('secret', $storage->getKopiaPassword());
+    }
+}


### PR DESCRIPTION
Mirror the existing Restic monitoring flow for repositories
  managed by Kopia. Scope is read-only: connect to the repository,
  verify snapshot manifests, capture latest-snapshot and total
  logical sizes, sum on-disk blob bytes, enforce the same 24h
  freshness check, and reuse the existing minimum / 2x-maximum
  size guards.

    - Storage gains TYPE_KOPIA plus kopiaBackend, kopiaConnectArgs and kopiaPassword fields. BackupConfiguration gains TYPE_READ_KOPIA, a kopiaCheckTags filter and getKopiaEnv(). Backup stores kopiaSize, kopiaTotalSize, kopiaTotalDedupSize.

    - BackupService::healhCheckBackup picks up a new case Storage::TYPE_KOPIA branch that writes a per-call ephemeral kopia config file (Kopia has no KOPIA_REPOSITORY env var equivalent to Restic), runs `kopia repository connect`, `kopia snapshot verify --verify-files-percent=0`, `kopia snapshot list --json` and `kopia blob list --json`, then cleans up the tempfile in a finally block.

    - Doctrine migration adds the new columns. EasyAdmin CRUD controllers expose the new fields with type-conditional visibility. Backup, BackupConfiguration and dashboard twig templates surface Kopia commands and sizes.

    - Dev fixtures register a Minio-backed Kopia storage and a `read-kopia` BackupConfiguration. The FrankenPHP Dockerfile installs the kopia binary alongside restic and rclone.

    - Unit tests cover Storage::isKopia, the new type registry entry, BackupConfiguration::getKopiaEnv shape and the kopiaCheckTags round-trip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Kopia as a backup storage backend with configurable parameters
  * Added Kopia backup metrics and health checks displayed in the admin dashboard
  * Added Kopia-specific command references and documentation in the admin interface for snapshot management and verification

* **Tests**
  * Added test coverage for Kopia configuration and storage entity functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/p-bizouard/CloudBackup/pull/80)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->