### PR TITLE
feat(kopia): use storageSubPath as repository --prefix

### DIFF
--- a/src/Controller/Admin/BackupConfigurationCrudController.php
+++ b/src/Controller/Admin/BackupConfigurationCrudController.php
@@ -113,7 +113,12 @@ class BackupConfigurationCrudController extends AbstractCrudController
             AssociationField::new('storage'),
             TextField::new('storageSubPath')
                 ->hideOnIndex()
-                ->setHelp('Restic subdirectory or Rclone full path with remote'),
+                ->setHelp(
+                    'Per-configuration sub-namespace inside the storage. Semantics depend on the storage type:<br />'
+                    .'&bull; <b>Restic</b>: subdirectory appended to the repository URL (e.g. <code>daily-mysql</code>).<br />'
+                    .'&bull; <b>Rclone</b>: full path including remote (e.g. <code>crypt:/backup</code>).<br />'
+                    .'&bull; <b>Kopia</b>: value of <code>--prefix</code> on <code>kopia repository connect</code> (e.g. <code>kopia/namespace/</code>) &mdash; lets several configurations share a single Kopia repository on the same backend bucket; leave empty to use the prefix already encoded in the storage&apos;s connect arguments.'
+                ),
             TextField::new('rcloneBackupDir')
                 ->hideOnIndex()
                 ->addCssClass('backupConfigurationType-field rclone')

--- a/src/Service/BackupService.php
+++ b/src/Service/BackupService.php
@@ -1354,12 +1354,21 @@ class BackupService
 
                 try {
                     // 1. Connect to the repository (per-call, ephemeral config file).
+                    // storageSubPath, when set, is passed as `--prefix` so several configurations
+                    // can share one Kopia repository on the same backend bucket.
+                    $parameters = ['KOPIA_CONFIG' => $configFile];
+                    $prefixClause = '';
+                    $storageSubPath = trim((string) $backup->getBackupConfiguration()->getStorageSubPath());
+                    if ('' !== $storageSubPath) {
+                        $prefixClause = ' --prefix="${KOPIA_PREFIX}"';
+                        $parameters['KOPIA_PREFIX'] = $storageSubPath;
+                    }
                     $command = \sprintf(
-                        'kopia repository connect %s %s --config-file="${KOPIA_CONFIG}"',
+                        'kopia repository connect %s %s%s --config-file="${KOPIA_CONFIG}"',
                         escapeshellarg((string) $storage->getKopiaBackend()),
                         (string) $storage->getKopiaConnectArgs(),
+                        $prefixClause,
                     );
-                    $parameters = ['KOPIA_CONFIG' => $configFile];
 
                     $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
                     $process = Process::fromShellCommandline($command, null, $env + $parameters);

--- a/templates/admin/backup/detail.html.twig
+++ b/templates/admin/backup/detail.html.twig
@@ -153,6 +153,9 @@
                                     ~ entity.instance.backupConfiguration.storage.kopiaBackend
                                     ~ ' '
                                     ~ entity.instance.backupConfiguration.storage.kopiaConnectArgs -}}
+                                {% if entity.instance.backupConfiguration.storageSubPath %}
+                                    {{- ' --prefix=' ~ entity.instance.backupConfiguration.storageSubPath -}}
+                                {% endif %}
                             </pre>
                             <small class="text-muted">
                                 Run <code>connect</code> once per workstation. All commands below reuse that local connection state.

--- a/templates/admin/backup_configuration/detail.html.twig
+++ b/templates/admin/backup_configuration/detail.html.twig
@@ -101,6 +101,9 @@
                                     ~ entity.instance.storage.kopiaBackend
                                     ~ ' '
                                     ~ entity.instance.storage.kopiaConnectArgs -}}
+                                {% if entity.instance.storageSubPath %}
+                                    {{- ' --prefix=' ~ entity.instance.storageSubPath -}}
+                                {% endif %}
                             </pre>
                             <small class="text-muted">
                                 Run <code>connect</code> once per workstation. All commands below reuse that local connection state.

--- a/templates/admin/dashboard.html.twig
+++ b/templates/admin/dashboard.html.twig
@@ -134,7 +134,10 @@
                         {{- 'kopia repository connect '
                             ~ backupConfiguration.storage.kopiaBackend
                             ~ ' '
-                            ~ backupConfiguration.storage.kopiaConnectArgs -}}{{ "\n" }}
+                            ~ backupConfiguration.storage.kopiaConnectArgs -}}
+                        {% if backupConfiguration.storageSubPath %}
+                            {{- ' --prefix=' ~ backupConfiguration.storageSubPath -}}
+                        {% endif %}{{ "\n" }}
 
                         {{- '# pick <SNAPSHOT_ID> from this list:' }}{{ "\n" }}
                         {{- 'kopia snapshot list --json' -}}


### PR DESCRIPTION
  Reuse the existing storageSubPath field for Kopia's
  per-configuration `--prefix` value, mirroring how the field
  already carries the Restic subdirectory and the Rclone full
  remote path. Avoids adding a dedicated kopiaPrefix column.

    - BackupService::healhCheckBackup, in the Kopia branch, appends `--prefix="${KOPIA_PREFIX}"` to `kopia repository connect` when storageSubPath is non-empty. The value is passed through Symfony Process parameter substitution so it never leaks into logged command lines. Empty value is a no-op and keeps the prefix already encoded in the storage's connect arguments.

    - BackupConfigurationCrudController expands the storageSubPath help text into a per-engine bullet list documenting Restic subdirectory, Rclone full path with remote, and the Kopia --prefix semantics (with `kopia/namespace/` as the example).

    - Backup detail, backup-configuration detail and dashboard restore-script twig blocks render the same `--prefix=<value>` suffix when storageSubPath is set, keeping copy-paste in sync with runtime behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Kopia backup storage now supports optional sub-path configuration with automatic prefix handling in connection commands.

* **Documentation**
  * Enhanced admin interface help text for the storage sub-path field with detailed guidance for each storage type.
  * Updated connection command displays across admin panels to reflect sub-path configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/p-bizouard/CloudBackup/pull/81)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->