### PR TITLE
build(docker): optimize image build pipeline and bump dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,18 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.4"
           coverage: none
           extensions: gd
+          tools: composer:v2
 
-      - name: Composer install
-        run: composer install --prefer-dist --no-progress --ansi
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: "--prefer-dist --ansi --no-progress"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan --error-format=github

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,12 @@ on:
   release:
     types: [published]
 
+env:
+  IMAGE: bizouap/cloud-backup
+
 jobs:
-  push_to_registry:
-    name: Push Docker image to Docker Hub
+  build:
+    name: Build and push
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -26,34 +29,34 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: bizouap/cloud-backup
+          images: ${{ env.IMAGE }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push Docker image
-        id: push
+      - name: Build and push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/frankenphp/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+          target: prod
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          target: prod
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: index.docker.io/bizouap/cloud-backup
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-name: index.docker.io/${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true

--- a/docker/frankenphp/Dockerfile
+++ b/docker/frankenphp/Dockerfile
@@ -10,81 +10,104 @@ ENTRYPOINT  ["/bin/sh", "-c"]
 # Install on launch, build to produce entrypoints and manifest.json, then watch for changes
 CMD ["npm install && npm run build && npm run watch"]
 
-FROM dunglas/frankenphp:1.10 AS dev
+# Node build stage pinned to native build platform — avoids QEMU on cross-arch builds
+FROM --platform=$BUILDPLATFORM node:24-alpine AS assets-build
 
-ENV DOCKER_USER=1000
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
+
+COPY assets assets
+COPY public public
+COPY webpack.config.js ./
+
+RUN npm run build
+
+#
+# base — runtime essentials shared by dev + prod (no dev-only tooling)
+#
+FROM dunglas/frankenphp:1.12.2 AS base
+
+ARG TARGETARCH
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
-RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
-
-# Override php memory limit in php.ini to 512M
+# Override php memory limit
 RUN echo "memory_limit = 512M" >> $PHP_INI_DIR/conf.d/memory-limit.ini
 
-RUN apt update \
-    && apt install -y wget gnupg lsb-release \
-    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
-    && apt update \
-    && apt install -y \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        wget gnupg lsb-release ca-certificates curl unzip bzip2 \
         libcurl4-gnutls-dev zlib1g-dev libicu-dev g++ libxml2-dev libpq-dev libonig-dev libzip-dev libldb-dev libpng-dev \
-        git unzip procps \
+        git \
         locales \
         sshfs sshpass \
         postgresql-client \
         mariadb-client \
-        graphviz \
-        bzip2 \
         python3-keystoneclient \
         python3-swiftclient \
         python3-openstackclient
 
-ARG KUBE_VERSION=1.33
-RUN curl -fsSL https://pkgs.k8s.io/core:/stable:/v${KUBE_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/kubernetes-apt-keyring.gpg \
+# kubectl
+ARG KUBE_VERSION=1.36
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    curl -fsSL https://pkgs.k8s.io/core:/stable:/v${KUBE_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/kubernetes-apt-keyring.gpg \
     && chmod 644 /etc/apt/kubernetes-apt-keyring.gpg \
     && echo 'deb [signed-by=/etc/apt/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v'${KUBE_VERSION}'/deb/ /' | tee /etc/apt/sources.list.d/kubernetes.list \
     && chmod 644 /etc/apt/sources.list.d/kubernetes.list \
-    && apt update \
-    && apt install -y kubectl
+    && apt-get update \
+    && apt-get install -y --no-install-recommends kubectl
 
-ARG RCLONE_VERSION=1.72.0
-RUN curl -fsSL "https://github.com/rclone/rclone/releases/download/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-amd64.zip" -o rclone.zip \
-    && unzip rclone.zip \
-    && mv "rclone-v${RCLONE_VERSION}-linux-amd64/rclone" /usr/local/bin/ \
+# rclone — arch-aware
+ARG RCLONE_VERSION=1.74.1
+RUN curl -fsSL "https://github.com/rclone/rclone/releases/download/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-${TARGETARCH}.zip" -o /tmp/rclone.zip \
+    && unzip -q /tmp/rclone.zip -d /tmp \
+    && mv "/tmp/rclone-v${RCLONE_VERSION}-linux-${TARGETARCH}/rclone" /usr/local/bin/ \
     && chmod +x /usr/local/bin/rclone \
-    && rm -rf rclone* \
-    && apt-get autoremove && apt-get autoclean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /tmp/rclone*
 
+# restic — arch-aware (uses amd64/arm64 naming)
 ARG RESTIC_VERSION=0.18.1
-RUN wget --quiet "https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_amd64.bz2" \
-    && bzip2 -d "restic_${RESTIC_VERSION}_linux_amd64.bz2" \
-    && mv "restic_${RESTIC_VERSION}_linux_amd64" /usr/local/bin/restic \
+RUN wget --quiet "https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_${TARGETARCH}.bz2" -O /tmp/restic.bz2 \
+    && bzip2 -d /tmp/restic.bz2 \
+    && mv /tmp/restic /usr/local/bin/restic \
     && chmod +x /usr/local/bin/restic
 
+# kopia — maps amd64→x64, arm64→arm64
 ARG KOPIA_VERSION=0.22.3
-RUN curl -fsSL "https://github.com/kopia/kopia/releases/download/v${KOPIA_VERSION}/kopia-${KOPIA_VERSION}-linux-x64.tar.gz" \
-        -o /tmp/kopia.tar.gz \
+RUN case "${TARGETARCH}" in \
+        amd64) KOPIA_ARCH=x64 ;; \
+        arm64) KOPIA_ARCH=arm64 ;; \
+        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/kopia/kopia/releases/download/v${KOPIA_VERSION}/kopia-${KOPIA_VERSION}-linux-${KOPIA_ARCH}.tar.gz" -o /tmp/kopia.tar.gz \
     && tar -xzf /tmp/kopia.tar.gz -C /tmp \
-    && mv "/tmp/kopia-${KOPIA_VERSION}-linux-x64/kopia" /usr/local/bin/kopia \
+    && mv "/tmp/kopia-${KOPIA_VERSION}-linux-${KOPIA_ARCH}/kopia" /usr/local/bin/kopia \
     && chmod +x /usr/local/bin/kopia \
-    && rm -rf /tmp/kopia.tar.gz "/tmp/kopia-${KOPIA_VERSION}-linux-x64"
+    && rm -rf /tmp/kopia*
 
 RUN install-php-extensions \
-	pdo_pgsql \
-	gd \
-	intl \
-	zip \
-	opcache \
+    pdo_pgsql \
+    gd \
+    intl \
+    zip \
+    opcache \
     mbstring \
     bcmath \
     sockets \
     redis
 
 RUN echo "user:user:${USER:-1000}:${USER:-1000}:Dev user:/:/sbin/nologin" >> /etc/passwd \
-      && mkdir /.ssh /.cache \
-      && chown ${USER:-1000}:${USER:-1000} /.ssh /.cache \
-      && chown -R ${USER}:${USER} /data/caddy /config/caddy
+    && mkdir /.ssh /.cache \
+    && chown ${USER:-1000}:${USER:-1000} /.ssh /.cache \
+    && chown -R ${USER}:${USER} /data/caddy /config/caddy
 
 # Caddyfile.d is not used, so we remove the import line to avoid warning messages
 RUN sed -e '/import Caddyfile\.d/d' -i /etc/frankenphp/Caddyfile
@@ -92,41 +115,42 @@ RUN sed -e '/import Caddyfile\.d/d' -i /etc/frankenphp/Caddyfile
 COPY --chmod=755 docker/frankenphp/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
 ENTRYPOINT ["docker-entrypoint"]
 
+#
+# dev — adds debug/dev tools on top of base
+#
+FROM base AS dev
+
+ENV DOCKER_USER=1000
+
+RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
+    && apt-get install -y --no-install-recommends \
+        procps \
+        graphviz
+
 CMD [ "frankenphp", "run", "--config", "/etc/frankenphp/Caddyfile", "--watch" ]
 
-FROM node:24-alpine AS assets-build
-
-WORKDIR /app
-
-COPY package*.json \
-    ./
-
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci
-
-COPY assets assets
-COPY public public
-COPY webpack.config.js \
-    ./
-
-RUN npm run build
-
-FROM dev AS prod
+#
+# prod — slim runtime, vendor + assets baked in
+#
+FROM base AS prod
 
 RUN cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 
-COPY composer.json \
-    composer.lock \
-    ./
-
 ENV APP_ENV=prod
+
+COPY composer.json composer.lock ./
 
 RUN --mount=type=cache,target=/tmp/composer-cache \
     COMPOSER_CACHE_DIR=/tmp/composer-cache composer install \
     --no-dev \
     --no-interaction \
     --optimize-autoloader \
-    --no-scripts
+    --no-scripts \
+    --no-autoloader
 
 # Copy project files to workdir
 COPY bin bin
@@ -138,6 +162,9 @@ COPY translations translations
 COPY migrations migrations
 
 COPY --from=assets-build /app/public/build /app/public/build
+
+# Generate authoritative classmap now that src is present
+RUN composer dump-autoload --no-dev --classmap-authoritative
 
 # Enable worker mode
 ENV FRANKENPHP_CONFIG="worker ./public/index.php"


### PR DESCRIPTION
  Restructure the FrankenPHP image into base/dev/prod stages so
  production no longer carries dev-only tooling (procps, graphviz)
  or its own composer step duplicated from base. The asset build
  stage is pinned to $BUILDPLATFORM to avoid QEMU on cross-arch
  builds, and apt + npm + composer caches are mounted so repeated
  builds skip network round-trips.

  Production composer install now runs in two phases: dependencies
  without the autoloader, then `dump-autoload --classmap-authoritative`
  after `src/` is copied. This keeps the dependency layer cacheable
  across source-only changes.

  Binary downloads (rclone, restic, kopia) are made arch-aware via
  $TARGETARCH so the same Dockerfile produces a working amd64 or
  arm64 image.

  CI:
  - bump actions/checkout v3 → v4
  - swap raw `composer install` for ramsey/composer-install@v3 to cache the vendor tree across runs

  Release:
  - drop the arm64 matrix and the digest-merge job; build amd64 only and push tags directly from the single job

  Bumps:
  - FrankenPHP 1.10 → 1.12.2 (pinned)
  - kubectl    1.33 → 1.36
  - rclone     1.72.0 → 1.74.1