### PR TITLE
build(docker): upgrade pg_dump via PGDG apt repo

### DIFF
--- a/docker/frankenphp/Dockerfile
+++ b/docker/frankenphp/Dockerfile
@@ -44,11 +44,22 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         wget gnupg lsb-release ca-certificates curl unzip bzip2 \
+    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+        | gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg \
+    && echo "deb [signed-by=/etc/apt/trusted.gpg.d/postgresql.gpg] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" \
+        > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
         libcurl4-gnutls-dev zlib1g-dev libicu-dev g++ libxml2-dev libpq-dev libonig-dev libzip-dev libldb-dev libpng-dev \
         git \
         locales \
         sshfs sshpass \
-        postgresql-client \
+        postgresql-client-13 \
+        postgresql-client-14 \
+        postgresql-client-15 \
+        postgresql-client-16 \
+        postgresql-client-17 \
+        postgresql-client-18 \
         mariadb-client \
         python3-keystoneclient \
         python3-swiftclient \


### PR DESCRIPTION
  Add apt.postgresql.org PGDG repo to frankenphp base stage.
  Replace generic postgresql-client with version-pinned clients 13–18.
  pg_wrapper now resolves /usr/bin/pg_dump to PG 18.
  Drop EOL clients 11 + 12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker configuration to include explicit PostgreSQL client packages across multiple database versions for enhanced compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/p-bizouard/CloudBackup/pull/88)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->