### PR TITLE
feat(admin): add status filter to backups list

### DIFF
--- a/src/Controller/Admin/BackupCrudController.php
+++ b/src/Controller/Admin/BackupCrudController.php
@@ -13,6 +13,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\ChoiceFilter;
 use Override;
 use Symfony\Component\Workflow\Registry;
 
@@ -63,8 +64,14 @@ class BackupCrudController extends AbstractCrudController
     #[Override]
     public function configureFilters(Filters $filters): Filters
     {
+        $places = array_keys($this->workflowRegistry->get(new Backup())->getDefinition()->getPlaces());
+
         return $filters
             ->add('backupConfiguration')
+            ->add(
+                ChoiceFilter::new('currentPlace', 'Status')
+                    ->setChoices(array_combine($places, $places))
+            )
         ;
     }
 


### PR DESCRIPTION
Add ChoiceFilter on currentPlace in BackupCrudController. Choices sourced from Workflow definition places, matching the existing ChoiceField on currentPlace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a workflow status filter in backup administration, enabling users to filter backups by their current workflow state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/p-bizouard/CloudBackup/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->