### PR TITLE
refactor(backup): strategy pattern for BackupService

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   linting:
@@ -27,3 +27,66 @@ jobs:
 
       - name: Run Rector
         run: vendor/bin/rector --dry-run
+
+  tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          coverage: pcov
+          extensions: gd
+          tools: composer:v2
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: "--prefer-dist --ansi --no-progress"
+
+      - name: Run PHPUnit with coverage
+        run: |
+          vendor/bin/phpunit \
+            --coverage-cobertura=coverage.cobertura.xml \
+            --coverage-clover=coverage.clover.xml \
+            --coverage-text=coverage.txt \
+            --log-junit=junit.xml
+
+      - name: Coverage summary (markdown)
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: coverage.cobertura.xml
+          badge: true
+          fail_below_min: false
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: true
+          indicators: true
+          output: both
+          thresholds: "50 80"
+
+      - name: Comment coverage on PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          recreate: true
+          path: code-coverage-results.md
+
+      - name: Append coverage to job summary
+        if: always()
+        run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ github.run_id }}
+          path: |
+            coverage.cobertura.xml
+            coverage.clover.xml
+            coverage.txt
+            junit.xml
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@ yarn-error.log
 ###> phpunit/phpunit ###
 /phpunit.xml
 .phpunit.result.cache
+.phpunit.cache
 ###< phpunit/phpunit ###

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -49,9 +49,9 @@ services:
         arguments:
             - "ticket"
 
-    App\Service\BackupService:
+    App\Backup\Path\TemporaryPathResolver:
         arguments:
-            - "%env(TEMPORARY_DOWNLOAD_DIRECTORY)%"
+            $temporaryDownloadDirectory: "%env(TEMPORARY_DOWNLOAD_DIRECTORY)%"
 
     App\Service\MailerService:
         arguments:

--- a/docker/frankenphp/Dockerfile
+++ b/docker/frankenphp/Dockerfile
@@ -142,6 +142,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         procps \
         graphviz
 
+# pcov: code-coverage driver for phpunit (low overhead, dev only).
+# Disabled by default; enable via `php -d pcov.enabled=1 vendor/bin/phpunit --coverage-text`.
+RUN install-php-extensions pcov \
+    && { \
+        echo "pcov.enabled=0"; \
+        echo "pcov.directory=/app/src"; \
+        echo "pcov.exclude=\"~vendor~\""; \
+    } > $PHP_INI_DIR/conf.d/pcov.ini
+
 CMD [ "frankenphp", "run", "--config", "/etc/frankenphp/Caddyfile", "--watch" ]
 
 #

--- a/src/Backup/Logging/BackupLogger.php
+++ b/src/Backup/Logging/BackupLogger.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Logging;
+
+use App\Entity\Backup;
+use App\Entity\Log;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+
+class BackupLogger
+{
+    private const array PSR_LEVEL_MAP = [
+        Log::LOG_ERROR => 'error',
+        Log::LOG_WARNING => 'warning',
+        Log::LOG_INFO => 'info',
+        Log::LOG_NOTICE => 'notice',
+    ];
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function log(Backup $backup, string $level, string $message): void
+    {
+        if (!isset(self::PSR_LEVEL_MAP[$level])) {
+            throw new InvalidArgumentException(\sprintf('Unsupported log level: %s', $level));
+        }
+
+        $psrMethod = self::PSR_LEVEL_MAP[$level];
+        $this->logger->{$psrMethod}($message);
+
+        $log = new Log();
+        $log->setLevel($level);
+        $log->setMessage($message);
+
+        $backup->addLog($log);
+
+        $this->entityManager->persist($log);
+        $this->entityManager->persist($backup);
+        $this->entityManager->flush();
+    }
+
+    public function formatParameters(mixed $parameters): string
+    {
+        return strip_tags(json_encode($parameters, \JSON_PRETTY_PRINT));
+    }
+}

--- a/src/Backup/Path/TemporaryPathResolver.php
+++ b/src/Backup/Path/TemporaryPathResolver.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Path;
+
+use App\Entity\Backup;
+use App\Entity\BackupConfiguration;
+
+final class TemporaryPathResolver
+{
+    public function __construct(private readonly string $temporaryDownloadDirectory)
+    {
+    }
+
+    public function resolve(Backup $backup): string
+    {
+        $configuration = $backup->getBackupConfiguration();
+
+        if (BackupConfiguration::TYPE_SSHFS === $configuration->getType()) {
+            return \sprintf('%s/%s', $this->temporaryDownloadDirectory, $backup->getName(false));
+        }
+
+        $extension = $configuration->getExtension();
+        if (null !== $extension) {
+            return \sprintf('%s/%s.%s', $this->temporaryDownloadDirectory, $backup->getName(false), $extension);
+        }
+
+        return \sprintf('%s/%s', $this->temporaryDownloadDirectory, $backup->getName(false));
+    }
+}

--- a/src/Backup/Process/ProcessExecutionException.php
+++ b/src/Backup/Process/ProcessExecutionException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Process;
+
+use RuntimeException;
+
+final class ProcessExecutionException extends RuntimeException
+{
+    public function __construct(public readonly ProcessOutcome $outcome, ?string $message = null)
+    {
+        parent::__construct($message ?? \sprintf(
+            'Process failed (exit %d): %s | stderr: %s',
+            $outcome->exitCode,
+            $outcome->command,
+            $outcome->errorOutput,
+        ));
+    }
+}

--- a/src/Backup/Process/ProcessOutcome.php
+++ b/src/Backup/Process/ProcessOutcome.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Process;
+
+final readonly class ProcessOutcome
+{
+    public function __construct(
+        public bool $successful,
+        public string $output,
+        public string $errorOutput,
+        public int $exitCode,
+        public string $command,
+    ) {
+    }
+}

--- a/src/Backup/Process/ProcessRunner.php
+++ b/src/Backup/Process/ProcessRunner.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Process;
+
+use Symfony\Component\Process\Exception\RuntimeException as SymfonyProcessRuntimeException;
+use Symfony\Component\Process\Process;
+
+final class ProcessRunner implements ProcessRunnerInterface
+{
+    public function runShell(string $command, array $env = [], ?int $timeoutSeconds = null): ProcessOutcome
+    {
+        $process = Process::fromShellCommandline($command, null, $env);
+        if (null !== $timeoutSeconds) {
+            $process->setTimeout($timeoutSeconds);
+        }
+
+        try {
+            $process->run();
+        } catch (SymfonyProcessRuntimeException $e) {
+            $processOutcome = new ProcessOutcome(
+                successful: false,
+                output: $process->getOutput(),
+                errorOutput: $process->getErrorOutput() ?: $e->getMessage(),
+                exitCode: (int) ($process->getExitCode() ?? -1),
+                command: $command,
+            );
+            throw new ProcessExecutionException($processOutcome, \sprintf('Process launch/runtime failure: %s', $e->getMessage()));
+        }
+
+        return new ProcessOutcome(
+            successful: $process->isSuccessful(),
+            output: $process->getOutput(),
+            errorOutput: $process->getErrorOutput(),
+            exitCode: (int) ($process->getExitCode() ?? -1),
+            command: $command,
+        );
+    }
+}

--- a/src/Backup/Process/ProcessRunnerInterface.php
+++ b/src/Backup/Process/ProcessRunnerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Process;
+
+interface ProcessRunnerInterface
+{
+    /**
+     * Run a shell command with the given environment and timeout.
+     *
+     * @param array<string, scalar|null> $env
+     */
+    public function runShell(string $command, array $env = [], ?int $timeoutSeconds = null): ProcessOutcome;
+}

--- a/src/Backup/Source/AbstractBackupSource.php
+++ b/src/Backup/Source/AbstractBackupSource.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Source;
+
+use App\Backup\Logging\BackupLogger;
+use App\Backup\Path\TemporaryPathResolver;
+use App\Backup\Process\ProcessExecutionException;
+use App\Backup\Process\ProcessOutcome;
+use App\Backup\Process\ProcessRunnerInterface;
+use App\Backup\Storage\StorageBackendRegistry;
+use App\Entity\Backup;
+use App\Entity\Log;
+
+abstract class AbstractBackupSource implements BackupSourceInterface
+{
+    public function __construct(
+        protected readonly ProcessRunnerInterface $processRunner,
+        protected readonly BackupLogger $backupLogger,
+        protected readonly TemporaryPathResolver $pathResolver,
+        protected readonly StorageBackendRegistry $storageBackends,
+    ) {
+    }
+
+    public function onDump(Backup $backup): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('%s : Nothing to do', $backup->getCurrentPlace()));
+    }
+
+    public function isDownloadComplete(Backup $backup): bool
+    {
+        return true;
+    }
+
+    public function isLocallyCleaned(Backup $backup): bool
+    {
+        return true;
+    }
+
+    public function getSnapshotStatus(Backup $backup): ?string
+    {
+        return null;
+    }
+
+    protected function failOrLog(Backup $backup, ProcessOutcome $processOutcome, string $context): void
+    {
+        if (!$processOutcome->successful) {
+            $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s - %s', $context, $processOutcome->errorOutput));
+            throw new ProcessExecutionException($processOutcome);
+        }
+        $this->backupLogger->log($backup, Log::LOG_INFO, $processOutcome->output);
+    }
+}

--- a/src/Backup/Source/BackupSourceInterface.php
+++ b/src/Backup/Source/BackupSourceInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Source;
+
+use App\Entity\Backup;
+use App\Entity\BackupConfiguration;
+
+interface BackupSourceInterface
+{
+    public function supports(BackupConfiguration $backupConfiguration): bool;
+
+    public function onDump(Backup $backup): void;
+
+    public function download(Backup $backup): void;
+
+    public function isDownloadComplete(Backup $backup): bool;
+
+    public function cleanupLocal(Backup $backup): void;
+
+    public function isLocallyCleaned(Backup $backup): bool;
+
+    public function upload(Backup $backup): void;
+
+    /**
+     * Snapshot readiness state for guards (null = none, "active" = ready, anything else = still pending).
+     */
+    public function getSnapshotStatus(Backup $backup): ?string;
+}

--- a/src/Backup/Source/BackupSourceRegistry.php
+++ b/src/Backup/Source/BackupSourceRegistry.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Source;
+
+use App\Entity\BackupConfiguration;
+use RuntimeException;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+class BackupSourceRegistry
+{
+    /** @var iterable<BackupSourceInterface> */
+    private readonly iterable $sources;
+
+    /** @param iterable<BackupSourceInterface> $sources */
+    public function __construct(
+        #[AutowireIterator('app.backup.source')]
+        iterable $sources,
+    ) {
+        $this->sources = $sources;
+    }
+
+    public function forConfiguration(BackupConfiguration $backupConfiguration): BackupSourceInterface
+    {
+        foreach ($this->sources as $source) {
+            if ($source->supports($backupConfiguration)) {
+                return $source;
+            }
+        }
+
+        throw new RuntimeException(\sprintf('No backup source supports type "%s"', (string) $backupConfiguration->getType()));
+    }
+}

--- a/src/Backup/Source/DumpSource.php
+++ b/src/Backup/Source/DumpSource.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Source;
+
+use App\Backup\Logging\BackupLogger;
+use App\Backup\Path\TemporaryPathResolver;
+use App\Backup\Process\ProcessExecutionException;
+use App\Backup\Process\ProcessRunnerInterface;
+use App\Backup\Ssh\SshKeyMaterializer;
+use App\Backup\Ssh\SshOptionsBuilder;
+use App\Backup\Storage\ResticStorageBackend;
+use App\Backup\Storage\StorageBackendRegistry;
+use App\Entity\Backup;
+use App\Entity\BackupConfiguration;
+use App\Entity\Log;
+use App\Utils\StringUtils;
+use InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.backup.source')]
+final class DumpSource extends AbstractBackupSource
+{
+    public const int DUMP_TIMEOUT = 3600 * 4;
+    public const array SUPPORTED_TYPES = [
+        BackupConfiguration::TYPE_MYSQL,
+        BackupConfiguration::TYPE_POSTGRESQL,
+        BackupConfiguration::TYPE_SQL_SERVER,
+        BackupConfiguration::TYPE_SSH_CMD,
+    ];
+
+    public function __construct(
+        ProcessRunnerInterface $processRunner,
+        BackupLogger $backupLogger,
+        TemporaryPathResolver $temporaryPathResolver,
+        StorageBackendRegistry $storageBackendRegistry,
+        private readonly SshOptionsBuilder $sshOptionsBuilder,
+        private readonly SshKeyMaterializer $sshKeyMaterializer,
+    ) {
+        parent::__construct($processRunner, $backupLogger, $temporaryPathResolver, $storageBackendRegistry);
+    }
+
+    public function supports(BackupConfiguration $backupConfiguration): bool
+    {
+        return \in_array($backupConfiguration->getType(), self::SUPPORTED_TYPES, true);
+    }
+
+    public function download(Backup $backup): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $backupDestination = $this->pathResolver->resolve($backup);
+        $configuration = $backup->getBackupConfiguration();
+        $host = $configuration->getHost();
+        $privateKeyPath = null;
+
+        try {
+            if (null !== $host) {
+                $privateKeyPath = null !== $host->getPrivateKey() ? $this->sshKeyMaterializer->writeTempKey((string) $host->getPrivateKey()) : null;
+                $privateKeyString = null !== $privateKeyPath ? '-i ${PRIVATE_KEY_PATH}' : null;
+                $sshpass = null !== $host->getPassword() ? 'sshpass -p ${SSHPASS}' : null;
+                $sshOptions = $this->sshOptionsBuilder->build($host);
+
+                $command = \sprintf(
+                    '%s ssh "${LOGIN}@${IP}" -p "${PORT}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null%s %s "${DUMP_COMMAND} | gzip -9" | gunzip > "${DESTINATION}"',
+                    $sshpass,
+                    $sshOptions,
+                    $privateKeyString
+                );
+                $parameters = [
+                    'SSHPASS' => $host->getPassword(),
+                    'LOGIN' => $host->getLogin(),
+                    'IP' => $host->getIp(),
+                    'PORT' => $host->getPort() ?? 22,
+                    'PRIVATE_KEY_PATH' => $privateKeyPath,
+                    'DUMP_COMMAND' => $configuration->getDumpCommand(),
+                    'DESTINATION' => $backupDestination,
+                ];
+            } else {
+                $command = 'sh -c "${DUMP_COMMAND}" > "${DESTINATION}"';
+                $parameters = [
+                    'DUMP_COMMAND' => $configuration->getDumpCommand(),
+                    'DESTINATION' => $backupDestination,
+                ];
+            }
+
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+            $outcome = $this->processRunner->runShell($command, $parameters, self::DUMP_TIMEOUT);
+
+            if (!$outcome->successful) {
+                $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing download - exec dump command - %s', $outcome->errorOutput));
+                throw new ProcessExecutionException($outcome);
+            }
+            $this->backupLogger->log($backup, Log::LOG_INFO, $outcome->output);
+
+            $backup->setSize((int) filesize($backupDestination));
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Backup size : %s', StringUtils::humanizeFileSize($backup->getSize())));
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, 'Dump done');
+        } finally {
+            $this->sshKeyMaterializer->cleanup($privateKeyPath);
+        }
+    }
+
+    public function isDownloadComplete(Backup $backup): bool
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $destination = $this->pathResolver->resolve($backup);
+        $minimum = (int) $backup->getBackupConfiguration()->getMinimumBackupSize();
+
+        if ($backup->getSize() >= $minimum) {
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, 'Backup downloaded');
+
+            return true;
+        }
+
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Backup not downloaded : %s < %s', StringUtils::humanizeFileSize(@filesize($destination) ?: 0), StringUtils::humanizeFileSize($minimum)));
+
+        return false;
+    }
+
+    public function upload(Backup $backup): void
+    {
+        $backend = $this->storageBackends->forStorage($backup->getBackupConfiguration()->getStorage());
+        if (!$backend instanceof ResticStorageBackend) {
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('%s : Nothing to do', $backup->getCurrentPlace()));
+
+            return;
+        }
+
+        $host = $backup->getBackupConfiguration()->getHost();
+        $tags = [
+            'host' => null !== $host ? $host->getSlug() : 'direct',
+            'configuration' => $backup->getBackupConfiguration()->getName(),
+        ];
+
+        $backend->uploadLocal($backup, $this->pathResolver->resolve($backup), $tags);
+    }
+
+    public function cleanupLocal(Backup $backup): void
+    {
+        $path = $this->pathResolver->resolve($backup);
+        if (file_exists($path)) {
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Remove local file - %s', $path));
+            unlink($path);
+        }
+
+        $remoteCleanCommand = $backup->getBackupConfiguration()->getRemoteCleanCommand();
+        if (BackupConfiguration::TYPE_SSH_CMD === $backup->getBackupConfiguration()->getType()
+            && null !== $remoteCleanCommand && '' !== $remoteCleanCommand
+        ) {
+            $this->executeRemoteCleanCommand($backup);
+        }
+    }
+
+    public function isLocallyCleaned(Backup $backup): bool
+    {
+        if (file_exists($this->pathResolver->resolve($backup))) {
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Backup location does exists - %s', $this->pathResolver->resolve($backup)));
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function executeRemoteCleanCommand(Backup $backup): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $host = $backup->getBackupConfiguration()->getHost();
+        if (null === $host) {
+            $message = 'Remote cleanup requires a host on the backup configuration';
+            $this->backupLogger->log($backup, Log::LOG_ERROR, $message);
+            throw new InvalidArgumentException($message);
+        }
+
+        $privateKeyPath = null;
+
+        try {
+            $privateKeyPath = null !== $host->getPrivateKey() ? $this->sshKeyMaterializer->writeTempKey((string) $host->getPrivateKey()) : null;
+            $privateKeyString = null !== $privateKeyPath ? '-i ${PRIVATE_KEY_PATH}' : null;
+            $sshpass = null !== $host->getPassword() ? 'sshpass -p ${SSHPASS}' : null;
+            $sshOptions = $this->sshOptionsBuilder->build($host);
+
+            $command = \sprintf(
+                '%s ssh "${LOGIN}@${IP}" -p "${PORT}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null%s %s "${REMOTE_CLEAN_COMMAND}"',
+                $sshpass,
+                $sshOptions,
+                $privateKeyString
+            );
+            $parameters = [
+                'SSHPASS' => $host->getPassword(),
+                'LOGIN' => $host->getLogin(),
+                'IP' => $host->getIp(),
+                'PORT' => $host->getPort() ?? 22,
+                'PRIVATE_KEY_PATH' => $privateKeyPath,
+                'REMOTE_CLEAN_COMMAND' => $backup->getBackupConfiguration()->getRemoteCleanCommand(),
+            ];
+
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+            $outcome = $this->processRunner->runShell($command, $parameters, self::DUMP_TIMEOUT);
+            $this->failOrLog($backup, $outcome, 'remote cleanup command');
+
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, 'Remote cleanup done');
+        } finally {
+            $this->sshKeyMaterializer->cleanup($privateKeyPath);
+        }
+    }
+}

--- a/src/Backup/Source/KubernetesDumpSource.php
+++ b/src/Backup/Source/KubernetesDumpSource.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Source;
+
+use App\Backup\Process\ProcessExecutionException;
+use App\Backup\Storage\ResticStorageBackend;
+use App\Entity\Backup;
+use App\Entity\BackupConfiguration;
+use App\Entity\Log;
+use App\Utils\StringUtils;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\Filesystem\Filesystem;
+
+#[AutoconfigureTag('app.backup.source')]
+final class KubernetesDumpSource extends AbstractBackupSource
+{
+    public const int DUMP_TIMEOUT = 3600 * 4;
+
+    public function supports(BackupConfiguration $backupConfiguration): bool
+    {
+        return BackupConfiguration::TYPE_KUBECONFIG === $backupConfiguration->getType();
+    }
+
+    public function download(Backup $backup): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $filesystem = new Filesystem();
+        $backupDestination = $this->pathResolver->resolve($backup);
+        $kubeconfigPath = null;
+
+        try {
+            $kubeconfigPath = $filesystem->tempnam('/tmp', 'kubeconfig_');
+            $filesystem->appendToFile($kubeconfigPath, str_replace("\r", '', $backup->getBackupConfiguration()->getKubeconfig()->getKubeconfig()."\n"));
+
+            $command = 'kubectl --kubeconfig ${KUBECONFIG_PATH} --namespace ${KUBE_NAMESPACE} exec --tty=false ${KUBE_RESOURCE} -- ${DUMP_COMMAND} > "${DESTINATION}"';
+            $parameters = [
+                'KUBECONFIG_PATH' => $kubeconfigPath,
+                'KUBE_NAMESPACE' => $backup->getBackupConfiguration()->getKubeNamespace(),
+                'KUBE_RESOURCE' => $backup->getBackupConfiguration()->getKubeResource(),
+                'DUMP_COMMAND' => $backup->getBackupConfiguration()->getDumpCommand(),
+                'DESTINATION' => $backupDestination,
+            ];
+
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+            $outcome = $this->processRunner->runShell($command, $parameters, self::DUMP_TIMEOUT);
+
+            if (!$outcome->successful) {
+                $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing download - exec dump command - %s', $outcome->errorOutput));
+                throw new ProcessExecutionException($outcome);
+            }
+            $this->backupLogger->log($backup, Log::LOG_INFO, $outcome->output);
+
+            $backup->setSize((int) filesize($backupDestination));
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Backup size : %s', StringUtils::humanizeFileSize($backup->getSize())));
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, 'Dump done');
+        } finally {
+            if (null !== $kubeconfigPath) {
+                @unlink($kubeconfigPath);
+            }
+        }
+    }
+
+    public function isDownloadComplete(Backup $backup): bool
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $destination = $this->pathResolver->resolve($backup);
+        $minimum = (int) $backup->getBackupConfiguration()->getMinimumBackupSize();
+
+        if ($backup->getSize() >= $minimum) {
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, 'Backup downloaded');
+
+            return true;
+        }
+
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Backup not downloaded : %s < %s', StringUtils::humanizeFileSize(@filesize($destination) ?: 0), StringUtils::humanizeFileSize($minimum)));
+
+        return false;
+    }
+
+    public function upload(Backup $backup): void
+    {
+        $backend = $this->storageBackends->forStorage($backup->getBackupConfiguration()->getStorage());
+        if (!$backend instanceof ResticStorageBackend) {
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('%s : Nothing to do', $backup->getCurrentPlace()));
+
+            return;
+        }
+
+        $kubeconfig = $backup->getBackupConfiguration()->getKubeconfig();
+        $tags = [
+            'host' => null !== $kubeconfig ? $kubeconfig->getName() : 'direct',
+            'configuration' => $backup->getBackupConfiguration()->getName(),
+        ];
+
+        $backend->uploadLocal($backup, $this->pathResolver->resolve($backup), $tags);
+    }
+
+    public function cleanupLocal(Backup $backup): void
+    {
+        $path = $this->pathResolver->resolve($backup);
+        if (file_exists($path)) {
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Remove local file - %s', $path));
+            unlink($path);
+        }
+    }
+}

--- a/src/Backup/Source/OsInstanceSource.php
+++ b/src/Backup/Source/OsInstanceSource.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Source;
+
+use App\Backup\Logging\BackupLogger;
+use App\Backup\Path\TemporaryPathResolver;
+use App\Backup\Process\ProcessExecutionException;
+use App\Backup\Process\ProcessRunnerInterface;
+use App\Backup\Storage\ResticStorageBackend;
+use App\Backup\Storage\StorageBackendRegistry;
+use App\Entity\Backup;
+use App\Entity\BackupConfiguration;
+use App\Entity\Log;
+use App\Utils\StringUtils;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.backup.source')]
+final class OsInstanceSource extends AbstractBackupSource
+{
+    public const int SNAPSHOT_TIMEOUT = 60;
+    public const int IMAGE_LIST_TIMEOUT = 60;
+    public const int DOWNLOAD_TIMEOUT = 3600 * 4;
+
+    public function __construct(
+        ProcessRunnerInterface $processRunner,
+        BackupLogger $backupLogger,
+        TemporaryPathResolver $temporaryPathResolver,
+        StorageBackendRegistry $storageBackendRegistry,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct($processRunner, $backupLogger, $temporaryPathResolver, $storageBackendRegistry);
+    }
+
+    public function supports(BackupConfiguration $backupConfiguration): bool
+    {
+        return BackupConfiguration::TYPE_OS_INSTANCE === $backupConfiguration->getType();
+    }
+
+    public function onDump(Backup $backup): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $existingStatus = $this->getSnapshotStatus($backup);
+        if (null !== $existingStatus) {
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Snapshot already found with %s', $existingStatus));
+
+            return;
+        }
+
+        $env = $backup->getBackupConfiguration()->getOsInstance()->getOSEnv();
+
+        $command = 'openstack server image create --name ${BACKUP_NAME} ${OS_INSTANCE_ID}';
+        $parameters = [
+            'BACKUP_NAME' => $backup->getName(),
+            'OS_INSTANCE_ID' => $backup->getBackupConfiguration()->getOsInstance()->getId(),
+        ];
+
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+        $outcome = $this->processRunner->runShell($command, $env + $parameters, self::SNAPSHOT_TIMEOUT);
+
+        if (!$outcome->successful) {
+            $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - openstack server image create - %s', $outcome->errorOutput));
+            throw new ProcessExecutionException($outcome);
+        }
+        $this->backupLogger->log($backup, Log::LOG_INFO, $outcome->output);
+    }
+
+    public function getSnapshotStatus(Backup $backup): ?string
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $image = $this->lookupImage($backup);
+        if (null === $image) {
+            return null;
+        }
+
+        if (null === $backup->getOsImageId() || null === $backup->getSize()) {
+            $backup->setOsImageId($image['ID']);
+            $backup->setChecksum($image['Checksum']);
+            $backup->setSize($image['Size']);
+
+            $this->entityManager->persist($backup);
+            $this->entityManager->flush();
+        }
+
+        return $image['Status'];
+    }
+
+    /**
+     * Look up the OpenStack image for this backup without mutating or persisting state.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function lookupImage(Backup $backup): ?array
+    {
+        $env = $backup->getBackupConfiguration()->getOsInstance()->getOSEnv();
+
+        $command = 'openstack image list --private --name ${BACKUP_NAME} --long -f json';
+        $parameters = ['BACKUP_NAME' => $backup->getName()];
+
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+        $outcome = $this->processRunner->runShell($command, $env + $parameters, self::IMAGE_LIST_TIMEOUT);
+
+        if (!$outcome->successful) {
+            $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing snapshot - openstack image list - %s', $outcome->errorOutput));
+            throw new ProcessExecutionException($outcome);
+        }
+        $this->backupLogger->log($backup, Log::LOG_INFO, $outcome->output);
+
+        $output = json_decode($outcome->output, true, 512, \JSON_THROW_ON_ERROR);
+        if (null === $output) {
+            $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing snapshot - openstack image list - %s - %s', $outcome->output, $outcome->errorOutput));
+            throw new ProcessExecutionException($outcome);
+        }
+
+        if ((is_countable($output) ? \count($output) : 0) === 0) {
+            return null;
+        }
+
+        return $output[0];
+    }
+
+    public function download(Backup $backup): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $env = $backup->getBackupConfiguration()->getOsInstance()->getOSEnv();
+
+        if (!$backup->getOsImageId()) {
+            $command = 'openstack image list --private --name ${BACKUP_NAME} --long -f json';
+            $parameters = ['BACKUP_NAME' => $backup->getName()];
+
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+            $outcome = $this->processRunner->runShell($command, $env + $parameters, self::IMAGE_LIST_TIMEOUT);
+
+            if (!$outcome->successful) {
+                $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing download - openstack image list - %s', $outcome->errorOutput));
+                throw new ProcessExecutionException($outcome);
+            }
+            $this->backupLogger->log($backup, Log::LOG_INFO, $outcome->output);
+
+            $output = json_decode($outcome->output, true, 512, \JSON_THROW_ON_ERROR);
+            if (null === $output) {
+                $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing download - openstack image list - %s - %s', $outcome->output, $outcome->errorOutput));
+                throw new ProcessExecutionException($outcome);
+            }
+
+            if ((is_countable($output) ? \count($output) : 0) === 0) {
+                return;
+            }
+
+            $backup->setOsImageId($output[0]['ID']);
+            $backup->setChecksum($output[0]['Checksum']);
+            $backup->setSize($output[0]['Size']);
+
+            $this->entityManager->persist($backup);
+            $this->entityManager->flush();
+        }
+
+        $imageDestination = $this->pathResolver->resolve($backup);
+
+        if (file_exists($imageDestination) && filesize($imageDestination) === $backup->getSize()) {
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, 'Openstack image already downloaded');
+
+            return;
+        }
+
+        $command = 'openstack image save --file ${IMAGE_DESTINATION} ${IMAGE_ID}';
+        $parameters = [
+            'IMAGE_DESTINATION' => $imageDestination,
+            'IMAGE_ID' => $backup->getOsImageId(),
+        ];
+
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+        $outcome = $this->processRunner->runShell($command, $env + $parameters, self::DOWNLOAD_TIMEOUT);
+
+        if (!$outcome->successful) {
+            $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing download - openstack image save - %s', $outcome->errorOutput));
+            $this->deleteOsImage($backup);
+            @unlink($imageDestination);
+            throw new ProcessExecutionException($outcome);
+        }
+        $this->backupLogger->log($backup, Log::LOG_INFO, $outcome->output);
+
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, 'Openstack image downloaded');
+    }
+
+    public function isDownloadComplete(Backup $backup): bool
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $imageDestination = $this->pathResolver->resolve($backup);
+
+        if (!$backup->getSize()) {
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, 'Openstack image not backuped');
+
+            return false;
+        }
+
+        if (!file_exists($imageDestination) || filesize($imageDestination) !== $backup->getSize()) {
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Openstack image not downloaded : %s != %s', StringUtils::humanizeFileSize(@filesize($imageDestination) ?: 0), StringUtils::humanizeFileSize($backup->getSize())));
+
+            return false;
+        }
+
+        return true;
+    }
+
+    public function upload(Backup $backup): void
+    {
+        $backend = $this->storageBackends->forStorage($backup->getBackupConfiguration()->getStorage());
+        if (!$backend instanceof ResticStorageBackend) {
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('%s : Nothing to do', $backup->getCurrentPlace()));
+
+            return;
+        }
+
+        $tags = [
+            'project' => $backup->getBackupConfiguration()->getOsInstance()->getOSProject()->getSlug(),
+            'instance' => $backup->getBackupConfiguration()->getOsInstance()->getSlug(),
+            'configuration' => $backup->getBackupConfiguration()->getName(),
+        ];
+
+        $backend->uploadLocal($backup, $this->pathResolver->resolve($backup), $tags);
+    }
+
+    public function cleanupLocal(Backup $backup): void
+    {
+        $path = $this->pathResolver->resolve($backup);
+        if (file_exists($path)) {
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Remove local file - %s', $path));
+            unlink($path);
+        }
+        $this->deleteOsImage($backup);
+    }
+
+    public function isLocallyCleaned(Backup $backup): bool
+    {
+        // Read-only existence check: no entity mutation or persist here.
+        if (null !== $this->lookupImage($backup)) {
+            return false;
+        }
+
+        if (file_exists($this->pathResolver->resolve($backup))) {
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Backup location does exists - %s', $this->pathResolver->resolve($backup)));
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function deleteOsImage(Backup $backup): void
+    {
+        if (null === $this->lookupImage($backup)) {
+            return;
+        }
+
+        $command = 'openstack image delete ${OS_IMAGE_ID}';
+        $parameters = ['OS_IMAGE_ID' => $backup->getOsImageId()];
+
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+        $outcome = $this->processRunner->runShell($command, $parameters + $backup->getBackupConfiguration()->getOsInstance()->getOSEnv(), self::IMAGE_LIST_TIMEOUT);
+
+        $this->failOrLog($backup, $outcome, 'openstack image delete');
+    }
+}

--- a/src/Backup/Source/RcloneSource.php
+++ b/src/Backup/Source/RcloneSource.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Source;
+
+use App\Backup\Process\ProcessExecutionException;
+use App\Backup\Storage\RcloneStorageBackend;
+use App\Entity\Backup;
+use App\Entity\BackupConfiguration;
+use App\Entity\Log;
+use InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\Filesystem\Filesystem;
+
+#[AutoconfigureTag('app.backup.source')]
+final class RcloneSource extends AbstractBackupSource
+{
+    public function supports(BackupConfiguration $backupConfiguration): bool
+    {
+        return BackupConfiguration::TYPE_RCLONE === $backupConfiguration->getType();
+    }
+
+    public function download(Backup $backup): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('%s : Nothing to do', $backup->getCurrentPlace()));
+    }
+
+    public function upload(Backup $backup): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $filesystem = new Filesystem();
+        $configFile = $filesystem->tempnam('/tmp', 'key_');
+
+        try {
+            $filesystem->appendToFile($configFile, $backup->getBackupConfiguration()->getCompleteRcloneConfiguration());
+
+            $dailyBackupDir = \sprintf('%s/%s', $backup->getBackupConfiguration()->getRcloneBackupDir(), date('Y-m-d'));
+            $command = 'rclone sync "${SOURCE_LOCATION}" "${REMOTE_STORAGE_LOCATION}" --backup-dir "${REMOTE_STORAGE_BACKUP}" --config "${RCLONE_CONFIG}" ${RCLONE_FLAGS}';
+            $parameters = [
+                'SOURCE_LOCATION' => $backup->getBackupConfiguration()->getRemotePath(),
+                'REMOTE_STORAGE_LOCATION' => $backup->getBackupConfiguration()->getStorageSubPath(),
+                'REMOTE_STORAGE_BACKUP' => $dailyBackupDir,
+                'RCLONE_CONFIG' => $configFile,
+                'RCLONE_FLAGS' => $backup->getBackupConfiguration()->getRcloneFlags(),
+            ];
+
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, nl2br($this->backupLogger->formatParameters($parameters))));
+            $outcome = $this->processRunner->runShell($command, $parameters, RcloneStorageBackend::UPLOAD_TIMEOUT);
+
+            if (!$outcome->successful) {
+                $stdErrIgnore = $backup->getBackupConfiguration()->getStdErrIgnore();
+                if (null !== $stdErrIgnore) {
+                    $filtered = preg_replace($stdErrIgnore, '', $outcome->errorOutput);
+                    if (null === $filtered) {
+                        $message = \sprintf('Invalid stdErrIgnore regex `%s`: %s', $stdErrIgnore, preg_last_error_msg());
+                        $this->backupLogger->log($backup, Log::LOG_ERROR, $message);
+                        throw new InvalidArgumentException($message);
+                    }
+                    if ('' === preg_replace('/^\s+/m', '', $filtered)) {
+                        $this->backupLogger->log($backup, Log::LOG_WARNING, \sprintf('Warning executing backup - rclone sync - %s', $outcome->errorOutput));
+
+                        return;
+                    }
+                }
+
+                $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - rclone sync - %s', $outcome->errorOutput));
+                throw new ProcessExecutionException($outcome);
+            }
+            $this->backupLogger->log($backup, Log::LOG_INFO, $outcome->output);
+        } finally {
+            @unlink($configFile);
+        }
+    }
+
+    public function cleanupLocal(Backup $backup): void
+    {
+        // Rclone uploads stream directly from the remote source; nothing local to clean.
+    }
+}

--- a/src/Backup/Source/ReadOnlySource.php
+++ b/src/Backup/Source/ReadOnlySource.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Source;
+
+use App\Entity\Backup;
+use App\Entity\BackupConfiguration;
+use App\Entity\Log;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.backup.source')]
+final class ReadOnlySource extends AbstractBackupSource
+{
+    private const array TYPES = [
+        BackupConfiguration::TYPE_READ_RESTIC,
+        BackupConfiguration::TYPE_READ_KOPIA,
+    ];
+
+    public function supports(BackupConfiguration $backupConfiguration): bool
+    {
+        return \in_array($backupConfiguration->getType(), self::TYPES, true);
+    }
+
+    public function download(Backup $backup): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('%s : Nothing to do', $backup->getCurrentPlace()));
+    }
+
+    public function upload(Backup $backup): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('%s : Nothing to do', $backup->getCurrentPlace()));
+    }
+
+    public function cleanupLocal(Backup $backup): void
+    {
+        // read-only sources never produce local artifacts.
+    }
+}

--- a/src/Backup/Source/SftpSource.php
+++ b/src/Backup/Source/SftpSource.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Source;
+
+use App\Backup\Logging\BackupLogger;
+use App\Backup\Path\TemporaryPathResolver;
+use App\Backup\Process\ProcessExecutionException;
+use App\Backup\Process\ProcessRunnerInterface;
+use App\Backup\Ssh\SshKeyMaterializer;
+use App\Backup\Storage\ResticStorageBackend;
+use App\Backup\Storage\StorageBackendRegistry;
+use App\Entity\Backup;
+use App\Entity\BackupConfiguration;
+use App\Entity\Log;
+use App\Utils\StringUtils;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\Filesystem\Filesystem;
+
+#[AutoconfigureTag('app.backup.source')]
+final class SftpSource extends AbstractBackupSource
+{
+    public const int MOUNT_TIMEOUT = 60;
+    public const int DOWNLOAD_SIZE_TIMEOUT = 60 * 10;
+
+    public function __construct(
+        ProcessRunnerInterface $processRunner,
+        BackupLogger $backupLogger,
+        TemporaryPathResolver $temporaryPathResolver,
+        StorageBackendRegistry $storageBackendRegistry,
+        private readonly SshKeyMaterializer $sshKeyMaterializer,
+    ) {
+        parent::__construct($processRunner, $backupLogger, $temporaryPathResolver, $storageBackendRegistry);
+    }
+
+    public function supports(BackupConfiguration $backupConfiguration): bool
+    {
+        return BackupConfiguration::TYPE_SFTP === $backupConfiguration->getType();
+    }
+
+    public function download(Backup $backup): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $host = $backup->getBackupConfiguration()->getHost();
+        $privateKeyPath = null;
+
+        try {
+            $privateKeyPath = null !== $host->getPrivateKey() ? $this->sshKeyMaterializer->writeTempKey((string) $host->getPrivateKey()) : null;
+            $privateKeyString = null !== $privateKeyPath ? '-i ${PRIVATE_KEY_PATH}' : null;
+
+            $command = \sprintf(
+                'sftp -P "${PORT}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null %s "${LOGIN}@${IP}:${REMOTE_DIRECTORY}" "${BACKUP_DESTINATION}"',
+                $privateKeyString
+            );
+            $parameters = [
+                'PORT' => $host->getPort() ?? 22,
+                'PRIVATE_KEY_PATH' => $privateKeyPath,
+                'LOGIN' => $host->getLogin(),
+                'IP' => $host->getIp(),
+                'REMOTE_DIRECTORY' => $backup->getBackupConfiguration()->getRemotePath(),
+                'BACKUP_DESTINATION' => $this->pathResolver->resolve($backup),
+            ];
+
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+            $outcome = $this->processRunner->runShell($command, $parameters, self::MOUNT_TIMEOUT);
+
+            if (!$outcome->successful) {
+                $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing download - exec dump command - %s', $outcome->errorOutput));
+                throw new ProcessExecutionException($outcome);
+            }
+            $this->backupLogger->log($backup, Log::LOG_INFO, $outcome->output);
+
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, 'Download done');
+
+            $backup->setSize($this->measureSize($backup));
+        } finally {
+            $this->sshKeyMaterializer->cleanup($privateKeyPath);
+        }
+    }
+
+    public function isDownloadComplete(Backup $backup): bool
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $destination = $this->pathResolver->resolve($backup);
+        $minimum = (int) $backup->getBackupConfiguration()->getMinimumBackupSize();
+
+        if ($backup->getSize() >= $minimum) {
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, 'Backup downloaded');
+
+            return true;
+        }
+
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Backup not downloaded : %s < %s', StringUtils::humanizeFileSize(@filesize($destination) ?: 0), StringUtils::humanizeFileSize($minimum)));
+
+        return false;
+    }
+
+    public function upload(Backup $backup): void
+    {
+        $backend = $this->storageBackends->forStorage($backup->getBackupConfiguration()->getStorage());
+        if (!$backend instanceof ResticStorageBackend) {
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('%s : Nothing to do', $backup->getCurrentPlace()));
+
+            return;
+        }
+
+        $tags = [
+            'host' => $backup->getBackupConfiguration()->getHost()->getSlug(),
+            'configuration' => $backup->getBackupConfiguration()->getName(),
+        ];
+
+        $backend->uploadLocal($backup, $this->pathResolver->resolve($backup), $tags);
+    }
+
+    public function cleanupLocal(Backup $backup): void
+    {
+        if ($this->isDownloadComplete($backup)) {
+            $path = $this->pathResolver->resolve($backup);
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Remove local directory - %s', $path));
+            new Filesystem()->remove($path);
+        }
+    }
+
+    public function isLocallyCleaned(Backup $backup): bool
+    {
+        if (file_exists($this->pathResolver->resolve($backup))) {
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Backup location does exists - %s', $this->pathResolver->resolve($backup)));
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function measureSize(Backup $backup): int
+    {
+        $command = 'du -sb "${BACKUP_DESTINATION}" | cut -f1';
+        $parameters = ['BACKUP_DESTINATION' => $this->pathResolver->resolve($backup)];
+
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+        $outcome = $this->processRunner->runShell($command, $parameters, self::DOWNLOAD_SIZE_TIMEOUT);
+
+        if (!$outcome->successful) {
+            $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error getting download size - %s', $outcome->errorOutput));
+            throw new ProcessExecutionException($outcome);
+        }
+        $this->backupLogger->log($backup, Log::LOG_INFO, $outcome->output);
+
+        return (int) $outcome->output;
+    }
+}

--- a/src/Backup/Source/SshResticSource.php
+++ b/src/Backup/Source/SshResticSource.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Source;
+
+use App\Backup\Logging\BackupLogger;
+use App\Backup\Path\TemporaryPathResolver;
+use App\Backup\Process\ProcessExecutionException;
+use App\Backup\Process\ProcessRunnerInterface;
+use App\Backup\Ssh\SshKeyMaterializer;
+use App\Backup\Ssh\SshOptionsBuilder;
+use App\Backup\Storage\ResticStorageBackend;
+use App\Backup\Storage\StorageBackendRegistry;
+use App\Entity\Backup;
+use App\Entity\BackupConfiguration;
+use App\Entity\Log;
+use InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\Filesystem\Filesystem;
+use Throwable;
+
+#[AutoconfigureTag('app.backup.source')]
+final class SshResticSource extends AbstractBackupSource
+{
+    public function __construct(
+        ProcessRunnerInterface $processRunner,
+        BackupLogger $backupLogger,
+        TemporaryPathResolver $temporaryPathResolver,
+        StorageBackendRegistry $storageBackendRegistry,
+        private readonly SshOptionsBuilder $sshOptionsBuilder,
+        private readonly SshKeyMaterializer $sshKeyMaterializer,
+    ) {
+        parent::__construct($processRunner, $backupLogger, $temporaryPathResolver, $storageBackendRegistry);
+    }
+
+    public function supports(BackupConfiguration $backupConfiguration): bool
+    {
+        return BackupConfiguration::TYPE_SSH_RESTIC === $backupConfiguration->getType();
+    }
+
+    public function download(Backup $backup): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('%s : Nothing to do', $backup->getCurrentPlace()));
+    }
+
+    public function upload(Backup $backup): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $configuration = $backup->getBackupConfiguration();
+        $host = $configuration->getHost();
+
+        if (null === $host || null === $host->getPrivateKey()) {
+            throw new InvalidArgumentException('SSH restic upload requires a host with a private key.');
+        }
+
+        $env = $configuration->getStorage()->getEnv() + $configuration->getResticEnv();
+
+        $filesystem = new Filesystem();
+        $privateKeyPath = null;
+        $scriptFilePath = null;
+
+        try {
+            $privateKeyPath = $this->sshKeyMaterializer->writeTempKey($host->getPrivateKey());
+
+            $scriptFilePath = $filesystem->tempnam('/tmp', 'env_');
+            $filesystem->appendToFile($scriptFilePath, \sprintf('#!/bin/bash%s', \PHP_EOL));
+            foreach ($env as $k => $v) {
+                $filesystem->appendToFile($scriptFilePath, \sprintf('export %s=%s%s', $k, escapeshellarg((string) $v), \PHP_EOL));
+            }
+            $filesystem->appendToFile($scriptFilePath, \sprintf(
+                'restic backup --tag host=%s --tag configuration=%s --host cloudbackup %s || exit 1%s',
+                $configuration->getHost()->getSlug(),
+                $configuration->getSlug(),
+                $configuration->getRemotePath(),
+                \PHP_EOL
+            ));
+
+            $scpCommand = \sprintf(
+                'scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentityFile=%s %s %s@%s:%s',
+                $privateKeyPath,
+                $scriptFilePath,
+                $configuration->getHost()->getLogin(),
+                $configuration->getHost()->getIp(),
+                $scriptFilePath,
+            );
+
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s`', $scpCommand));
+            $scpOutcome = $this->processRunner->runShell($scpCommand, [], ResticStorageBackend::UPLOAD_TIMEOUT);
+            if (!$scpOutcome->successful) {
+                $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - ssh restic scp - %s', $scpOutcome->errorOutput));
+                throw new ProcessExecutionException($scpOutcome);
+            }
+
+            $sshOptions = $this->sshOptionsBuilder->build($configuration->getHost());
+
+            $execCommand = \sprintf(
+                'ssh %s@%s -p %d -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null%s -o IdentityFile=%s "%s"',
+                $configuration->getHost()->getLogin(),
+                $configuration->getHost()->getIp(),
+                $configuration->getHost()->getPort() ?? 22,
+                $sshOptions,
+                $privateKeyPath,
+                \sprintf('sudo chmod 700 %s && sudo chown root:root %s && sudo %s', $scriptFilePath, $scriptFilePath, $scriptFilePath)
+            );
+
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s`', $execCommand));
+            $execOutcome = $this->processRunner->runShell($execCommand, [], ResticStorageBackend::UPLOAD_TIMEOUT);
+
+            try {
+                $this->removeRemoteScript($backup, $privateKeyPath, $scriptFilePath);
+            } catch (Throwable $cleanupError) {
+                $this->backupLogger->log($backup, Log::LOG_WARNING, \sprintf('Remote script cleanup failed (continuing): %s', $cleanupError->getMessage()));
+            }
+
+            if (!$execOutcome->successful) {
+                $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - ssh restic upload - %s', $execOutcome->errorOutput));
+                throw new ProcessExecutionException($execOutcome);
+            }
+            $this->backupLogger->log($backup, Log::LOG_INFO, $execOutcome->output);
+        } finally {
+            $this->sshKeyMaterializer->cleanup($privateKeyPath);
+            if (null !== $scriptFilePath) {
+                @unlink($scriptFilePath);
+            }
+        }
+    }
+
+    public function cleanupLocal(Backup $backup): void
+    {
+        // ssh-restic uploads happen entirely on the remote host; no local artifact to clean.
+    }
+
+    private function removeRemoteScript(Backup $backup, string $privateKeyPath, string $scriptFilePath): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $configuration = $backup->getBackupConfiguration();
+        $sshOptions = $this->sshOptionsBuilder->build($configuration->getHost());
+
+        $command = \sprintf(
+            'ssh %s@%s -p %d -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null%s -o IdentityFile=%s "sudo rm -f %s"',
+            $configuration->getHost()->getLogin(),
+            $configuration->getHost()->getIp(),
+            $configuration->getHost()->getPort() ?? 22,
+            $sshOptions,
+            $privateKeyPath,
+            $scriptFilePath,
+        );
+
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s`', $command));
+        $outcome = $this->processRunner->runShell($command, [], ResticStorageBackend::UPLOAD_TIMEOUT);
+
+        if (!$outcome->successful) {
+            $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - ssh restic remove script - %s', $outcome->errorOutput));
+            throw new ProcessExecutionException($outcome);
+        }
+        $this->backupLogger->log($backup, Log::LOG_INFO, $outcome->output);
+    }
+}

--- a/src/Backup/Source/SshfsSource.php
+++ b/src/Backup/Source/SshfsSource.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Source;
+
+use App\Backup\Logging\BackupLogger;
+use App\Backup\Path\TemporaryPathResolver;
+use App\Backup\Process\ProcessExecutionException;
+use App\Backup\Process\ProcessRunnerInterface;
+use App\Backup\Ssh\SshKeyMaterializer;
+use App\Backup\Ssh\SshOptionsBuilder;
+use App\Backup\Storage\ResticStorageBackend;
+use App\Backup\Storage\StorageBackendRegistry;
+use App\Entity\Backup;
+use App\Entity\BackupConfiguration;
+use App\Entity\Log;
+use Exception;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\Filesystem\Filesystem;
+
+#[AutoconfigureTag('app.backup.source')]
+final class SshfsSource extends AbstractBackupSource
+{
+    public const int MOUNT_TIMEOUT = 60;
+    public const int UMOUNT_TIMEOUT = 60;
+    public const int CHECK_TIMEOUT = 3600 * 4;
+
+    public function __construct(
+        ProcessRunnerInterface $processRunner,
+        BackupLogger $backupLogger,
+        TemporaryPathResolver $temporaryPathResolver,
+        StorageBackendRegistry $storageBackendRegistry,
+        private readonly SshOptionsBuilder $sshOptionsBuilder,
+        private readonly SshKeyMaterializer $sshKeyMaterializer,
+    ) {
+        parent::__construct($processRunner, $backupLogger, $temporaryPathResolver, $storageBackendRegistry);
+    }
+
+    public function supports(BackupConfiguration $backupConfiguration): bool
+    {
+        return BackupConfiguration::TYPE_SSHFS === $backupConfiguration->getType();
+    }
+
+    public function download(Backup $backup): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        if ($this->isMounted($backup)) {
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, 'Already mounted');
+
+            return;
+        }
+
+        $filesystem = new Filesystem();
+        $backupDestination = $this->pathResolver->resolve($backup);
+        $filesystem->mkdir($backupDestination);
+
+        $host = $backup->getBackupConfiguration()->getHost();
+        $privateKeyPath = null;
+
+        try {
+            $privateKeyPath = null !== $host->getPrivateKey() ? $this->sshKeyMaterializer->writeTempKey((string) $host->getPrivateKey()) : null;
+            $privateKeyString = null !== $privateKeyPath ? '-o IdentityFile="${PRIVATE_KEY_PATH}"' : null;
+            $sshpass = null !== $host->getPassword() ? 'echo "${SSHPASS}" | ' : null;
+            $sshOptions = $this->sshOptionsBuilder->build($host);
+
+            $command = \sprintf(
+                '%s sshfs "${LOGIN}@${IP}:${REMOTE_PATH}" "${DESTINATION}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null%s %s -o "uid=%d,gid=%d" -o ro %s',
+                $sshpass,
+                $sshOptions,
+                $privateKeyString,
+                posix_getuid(),
+                posix_getgid(),
+                $backup->getBackupConfiguration()->getDumpCommand()
+            );
+            $parameters = [
+                'SSHPASS' => $host->getPassword(),
+                'LOGIN' => $host->getLogin(),
+                'IP' => $host->getIp(),
+                'REMOTE_PATH' => $backup->getBackupConfiguration()->getRemotePath(),
+                'DESTINATION' => $backupDestination,
+                'PRIVATE_KEY_PATH' => $privateKeyPath,
+            ];
+
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+            $outcome = $this->processRunner->runShell($command, $parameters, self::MOUNT_TIMEOUT);
+
+            if (!$outcome->successful) {
+                $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing download - exec dump command - %s', $outcome->errorOutput));
+                throw new ProcessExecutionException($outcome);
+            }
+            $this->backupLogger->log($backup, Log::LOG_INFO, $outcome->output);
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, 'Mount done');
+        } finally {
+            $this->sshKeyMaterializer->cleanup($privateKeyPath);
+        }
+    }
+
+    public function isDownloadComplete(Backup $backup): bool
+    {
+        return $this->isMounted($backup);
+    }
+
+    public function upload(Backup $backup): void
+    {
+        $backend = $this->storageBackends->forStorage($backup->getBackupConfiguration()->getStorage());
+        if (!$backend instanceof ResticStorageBackend) {
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('%s : Nothing to do', $backup->getCurrentPlace()));
+
+            return;
+        }
+
+        $tags = [
+            'host' => $backup->getBackupConfiguration()->getHost()->getSlug(),
+            'configuration' => $backup->getBackupConfiguration()->getName(),
+        ];
+
+        $backend->uploadLocal($backup, $this->pathResolver->resolve($backup), $tags);
+    }
+
+    public function cleanupLocal(Backup $backup): void
+    {
+        $path = $this->pathResolver->resolve($backup);
+        if (!file_exists($path)) {
+            return;
+        }
+
+        if ($this->isMounted($backup)) {
+            $command = 'fusermount -u "${DIRECTORY}"';
+            $parameters = ['DIRECTORY' => $path];
+
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+            $outcome = $this->processRunner->runShell($command, $parameters, self::UMOUNT_TIMEOUT);
+
+            if (!$outcome->successful) {
+                $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing cleanup - exec umount command - %s', $outcome->errorOutput));
+                throw new ProcessExecutionException($outcome);
+            }
+            $this->backupLogger->log($backup, Log::LOG_INFO, $outcome->output);
+        }
+
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Remove local file - %s', $path));
+
+        $entries = is_countable(scandir($path)) ? \count(scandir($path)) : 0;
+        if (2 !== $entries) {
+            $message = \sprintf('Error executing cleanup - %s directory is not empty', $path);
+            $this->backupLogger->log($backup, Log::LOG_ERROR, $message);
+            throw new Exception($message);
+        }
+
+        rmdir($path);
+    }
+
+    public function isLocallyCleaned(Backup $backup): bool
+    {
+        if (file_exists($this->pathResolver->resolve($backup))) {
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Backup location does exists - %s', $this->pathResolver->resolve($backup)));
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function isMounted(Backup $backup): bool
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $command = 'grep -qsF "${DIRECTORY}" /proc/mounts';
+        $parameters = ['DIRECTORY' => $this->pathResolver->resolve($backup)];
+
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+        $outcome = $this->processRunner->runShell($command, $parameters, self::CHECK_TIMEOUT);
+
+        if (!$outcome->successful) {
+            $this->backupLogger->log($backup, Log::LOG_ERROR, 'checkDownloadedFUSE : not mounted');
+
+            return false;
+        }
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, 'checkDownloadedFUSE : mounted');
+
+        return true;
+    }
+}

--- a/src/Backup/Ssh/SshKeyMaterializer.php
+++ b/src/Backup/Ssh/SshKeyMaterializer.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Ssh;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+final class SshKeyMaterializer
+{
+    public function __construct(private readonly Filesystem $filesystem = new Filesystem())
+    {
+    }
+
+    public function writeTempKey(string $privateKey): string
+    {
+        $path = $this->filesystem->tempnam('/tmp', 'key_');
+        $this->filesystem->appendToFile($path, str_replace("\r", '', $privateKey."\n"));
+
+        return $path;
+    }
+
+    /**
+     * Best-effort removal of a materialized key file. Safe to call with null.
+     */
+    public function cleanup(?string $path): void
+    {
+        if (null === $path) {
+            return;
+        }
+        @unlink($path);
+    }
+}

--- a/src/Backup/Ssh/SshOptionsBuilder.php
+++ b/src/Backup/Ssh/SshOptionsBuilder.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Ssh;
+
+use App\Entity\Host;
+use InvalidArgumentException;
+
+final class SshOptionsBuilder
+{
+    public function build(?Host $host): string
+    {
+        if (null === $host || null === $host->getSshOptions() || '' === trim((string) $host->getSshOptions())) {
+            return '';
+        }
+
+        $sshOptions = trim((string) $host->getSshOptions());
+
+        if (!preg_match(Host::SSH_OPTIONS_PATTERN, $sshOptions)) {
+            throw new InvalidArgumentException('SSH options contain invalid characters. Only alphanumeric characters, spaces, and the following special characters are allowed: - = , + . / : _');
+        }
+
+        return ' '.$sshOptions;
+    }
+}

--- a/src/Backup/Storage/KopiaStorageBackend.php
+++ b/src/Backup/Storage/KopiaStorageBackend.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Storage;
+
+use App\Backup\Logging\BackupLogger;
+use App\Backup\Process\ProcessExecutionException;
+use App\Backup\Process\ProcessOutcome;
+use App\Backup\Process\ProcessRunnerInterface;
+use App\Entity\Backup;
+use App\Entity\Log;
+use App\Entity\Storage;
+use App\Utils\StringUtils;
+use DateTime;
+use Exception;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\Filesystem\Filesystem;
+
+#[AutoconfigureTag('app.backup.storage_backend')]
+final class KopiaStorageBackend implements StorageBackendInterface
+{
+    public const int CHECK_TIMEOUT = 3600;
+    public const int SIZE_MAX_RATIO = 2;
+
+    public function __construct(
+        private readonly ProcessRunnerInterface $processRunner,
+        private readonly BackupLogger $backupLogger,
+    ) {
+    }
+
+    public function supports(Storage $storage): bool
+    {
+        return $storage->isKopia();
+    }
+
+    public function initRepository(Backup $backup): void
+    {
+        // Kopia repositories are connected per healthCheck call, no global init step.
+    }
+
+    public function healthCheck(Backup $backup, bool $tryRepair = true): void
+    {
+        $storage = $backup->getBackupConfiguration()->getStorage();
+        $env = $storage->getEnv() + $backup->getBackupConfiguration()->getKopiaEnv();
+
+        $filesystem = new Filesystem();
+        $configFile = $filesystem->tempnam('/tmp', 'kopia_');
+
+        try {
+            $parameters = ['KOPIA_CONFIG' => $configFile];
+            $prefixClause = '';
+            $storageSubPath = trim((string) $backup->getBackupConfiguration()->getStorageSubPath());
+            if ('' !== $storageSubPath) {
+                $prefixClause = ' --prefix="${KOPIA_PREFIX}"';
+                $parameters['KOPIA_PREFIX'] = $storageSubPath;
+            }
+
+            $command = \sprintf(
+                'kopia repository connect %s %s%s --config-file="${KOPIA_CONFIG}"',
+                escapeshellarg((string) $storage->getKopiaBackend()),
+                (string) $storage->getKopiaConnectArgs(),
+                $prefixClause,
+            );
+            $this->run($backup, $command, $env + $parameters, $parameters);
+
+            $command = 'kopia --config-file="${KOPIA_CONFIG}" snapshot verify --verify-files-percent=0';
+            $this->run($backup, $command, $env + $parameters, $parameters);
+
+            $tagsClause = '';
+            $listParameters = $parameters;
+            $rawTags = trim((string) $backup->getBackupConfiguration()->getKopiaCheckTags());
+            if ('' !== $rawTags) {
+                foreach (preg_split('/\s+/', $rawTags) as $idx => $token) {
+                    $key = \sprintf('KOPIA_CHECK_TAG_%d', $idx);
+                    $tagsClause .= \sprintf(' --tags "${%s}"', $key);
+                    $listParameters[$key] = $token;
+                }
+            }
+            $command = 'kopia --config-file="${KOPIA_CONFIG}" snapshot list --json'.$tagsClause;
+            $outcome = $this->run($backup, $command, $env + $listParameters, $listParameters);
+
+            $snapshots = json_decode($outcome->output, true, 512, \JSON_THROW_ON_ERROR);
+            if (!\is_array($snapshots) || [] === $snapshots) {
+                $message = \sprintf('Cannot decode json or empty snapshot list : %s', $outcome->output);
+                $this->backupLogger->log($backup, Log::LOG_ERROR, $message);
+                throw new Exception($message);
+            }
+
+            usort($snapshots, static fn ($a, $b) => new DateTime($b['endTime']) <=> new DateTime($a['endTime']));
+
+            $this->backupLogger->log($backup, Log::LOG_INFO, json_encode($snapshots, \JSON_PRETTY_PRINT));
+
+            $lastBackup = new DateTime(preg_replace('/(\d+\-\d+\-\d+T\d+:\d+:\d+)\..*/', '$1', (string) $snapshots[0]['endTime']));
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Last backup : %s', $lastBackup->format('d/m/Y H:i')));
+
+            if ($lastBackup < new DateTime('yesterday')) {
+                $message = 'Last backup older than 24h';
+                $this->backupLogger->log($backup, Log::LOG_ERROR, $message);
+                throw new Exception($message);
+            }
+
+            $backup->setKopiaSize((int) ($snapshots[0]['stats']['totalSize'] ?? 0));
+            $backup->setKopiaTotalSize(array_sum(array_map(
+                static fn (array $snapshot): int => (int) ($snapshot['stats']['totalSize'] ?? 0),
+                $snapshots,
+            )));
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Stat kopiaSize : %s', StringUtils::humanizeFileSize($backup->getKopiaSize())));
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Stat kopiaTotalSize : %s', StringUtils::humanizeFileSize($backup->getKopiaTotalSize())));
+
+            $command = 'kopia --config-file="${KOPIA_CONFIG}" blob stats --raw';
+            $outcome = $this->run($backup, $command, $env + $parameters, $parameters);
+
+            if (1 !== preg_match('/^Total:\s+(\d+)\s*$/m', $outcome->output, $matches)) {
+                $message = \sprintf('Cannot read total dedup size from blob stats output : %s', $outcome->output);
+                $this->backupLogger->log($backup, Log::LOG_ERROR, $message);
+                throw new Exception($message);
+            }
+
+            $backup->setKopiaTotalDedupSize((int) $matches[1]);
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Stat kopiaTotalDedupSize : %s', StringUtils::humanizeFileSize($backup->getKopiaTotalDedupSize())));
+
+            if (null === $backup->getSize()) {
+                $backup->setSize($backup->getKopiaSize());
+            }
+
+            $minimumBackupSize = (int) $backup->getBackupConfiguration()->getMinimumBackupSize();
+            $kopiaSize = (int) $backup->getKopiaSize();
+
+            if ($kopiaSize <= $minimumBackupSize) {
+                $message = \sprintf('Kopia failed. Minimum backup size not met : %s < %s', StringUtils::humanizeFileSize($kopiaSize), StringUtils::humanizeFileSize($minimumBackupSize));
+                $this->backupLogger->log($backup, Log::LOG_NOTICE, $message);
+                throw new Exception($message);
+            }
+
+            if ($minimumBackupSize > 0 && $kopiaSize > self::SIZE_MAX_RATIO * $minimumBackupSize) {
+                $newMinimumBackupSize = (int) ($minimumBackupSize * (1 + (self::SIZE_MAX_RATIO - 1) / 2));
+                $message = \sprintf('Kopia backup size %s exceeds %dx the expected size %s. Updating expected size to %s.', StringUtils::humanizeFileSize($kopiaSize), self::SIZE_MAX_RATIO, StringUtils::humanizeFileSize($minimumBackupSize), StringUtils::humanizeFileSize($newMinimumBackupSize));
+                $this->backupLogger->log($backup, Log::LOG_NOTICE, $message);
+                $backup->getBackupConfiguration()->setMinimumBackupSize((string) $newMinimumBackupSize);
+            }
+        } finally {
+            @unlink($configFile);
+        }
+    }
+
+    public function prune(Backup $backup): void
+    {
+        // Kopia retention is configured server-side; no explicit prune action runs here.
+    }
+
+    /**
+     * @param array<string, scalar|null> $env
+     * @param array<string, scalar|null> $parameters
+     */
+    private function run(Backup $backup, string $command, array $env, array $parameters): ProcessOutcome
+    {
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+        $outcome = $this->processRunner->runShell($command, $env, self::CHECK_TIMEOUT);
+
+        if (!$outcome->successful) {
+            $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::healthCheck - %s - %s', self::class, $command, $outcome->errorOutput));
+            throw new ProcessExecutionException($outcome);
+        }
+
+        $this->backupLogger->log($backup, Log::LOG_INFO, $outcome->output);
+
+        return $outcome;
+    }
+}

--- a/src/Backup/Storage/RcloneStorageBackend.php
+++ b/src/Backup/Storage/RcloneStorageBackend.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Storage;
+
+use App\Backup\Logging\BackupLogger;
+use App\Backup\Process\ProcessExecutionException;
+use App\Backup\Process\ProcessOutcome;
+use App\Backup\Process\ProcessRunnerInterface;
+use App\Entity\Backup;
+use App\Entity\Log;
+use App\Entity\Storage;
+use App\Utils\StringUtils;
+use DateTime;
+use Exception;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\Filesystem\Filesystem;
+
+#[AutoconfigureTag('app.backup.storage_backend')]
+final class RcloneStorageBackend implements StorageBackendInterface
+{
+    public const int UPLOAD_TIMEOUT = 3600 * 4;
+    public const int CHECK_TIMEOUT = 3600;
+    public const int SIZE_MAX_RATIO = 2;
+
+    public function __construct(
+        private readonly ProcessRunnerInterface $processRunner,
+        private readonly BackupLogger $backupLogger,
+    ) {
+    }
+
+    public function supports(Storage $storage): bool
+    {
+        return $storage->isRclone();
+    }
+
+    public function initRepository(Backup $backup): void
+    {
+        // Rclone does not require explicit repository initialisation.
+    }
+
+    public function healthCheck(Backup $backup, bool $tryRepair = true): void
+    {
+        $filesystem = new Filesystem();
+        $configFile = $filesystem->tempnam('/tmp', 'key_');
+
+        try {
+            $filesystem->appendToFile($configFile, $backup->getBackupConfiguration()->getCompleteRcloneConfiguration());
+
+            if ($backup->getBackupConfiguration()->isSkipRcloneCheck()) {
+                $this->backupLogger->log($backup, Log::LOG_NOTICE, 'Skipping rclone check (skipRcloneCheck enabled on configuration)');
+            } else {
+                $this->runRcloneCheck($backup, $configFile);
+            }
+
+            $command = 'rclone size "${REMOTE_STORAGE_LOCATION}" --config "${RCLONE_CONFIG}" --json';
+            $parameters = [
+                'REMOTE_STORAGE_LOCATION' => $backup->getBackupConfiguration()->getStorageSubPath(),
+                'RCLONE_CONFIG' => $configFile,
+            ];
+
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+            $outcome = $this->processRunner->runShell($command, $parameters, self::CHECK_TIMEOUT);
+            $this->failOrLog($backup, $outcome, 'rclone size');
+
+            $output = json_decode($outcome->output, true, 512, \JSON_THROW_ON_ERROR);
+            if (null === $output) {
+                $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing rclone size - %s - %s', $outcome->output, $outcome->errorOutput));
+                throw new ProcessExecutionException($outcome);
+            }
+
+            $backup->setSize($output['bytes']);
+
+            $minimumBackupSize = (int) $backup->getBackupConfiguration()->getMinimumBackupSize();
+
+            if ($output['bytes'] <= $minimumBackupSize) {
+                $message = \sprintf('Rclone failed. Minimum backup size not met : %s < %s', StringUtils::humanizeFileSize($output['bytes']), StringUtils::humanizeFileSize($minimumBackupSize));
+                $this->backupLogger->log($backup, Log::LOG_NOTICE, $message);
+                throw new Exception($message);
+            }
+
+            if ($minimumBackupSize > 0 && $output['bytes'] > self::SIZE_MAX_RATIO * $minimumBackupSize) {
+                $newMinimumBackupSize = (int) ($minimumBackupSize * (1 + (self::SIZE_MAX_RATIO - 1) / 2));
+                $message = \sprintf('Rclone backup size %s exceeds %dx the expected size %s. Updating expected size to %s.', StringUtils::humanizeFileSize($output['bytes']), self::SIZE_MAX_RATIO, StringUtils::humanizeFileSize($minimumBackupSize), StringUtils::humanizeFileSize($newMinimumBackupSize));
+                $this->backupLogger->log($backup, Log::LOG_NOTICE, $message);
+                $backup->getBackupConfiguration()->setMinimumBackupSize((string) $newMinimumBackupSize);
+            }
+        } finally {
+            @unlink($configFile);
+        }
+    }
+
+    public function prune(Backup $backup): void
+    {
+        if (null === $backup->getBackupConfiguration()->getRcloneBackupDir() || '' === $backup->getBackupConfiguration()->getRcloneBackupDir()) {
+            return;
+        }
+
+        $filesystem = new Filesystem();
+        $configFile = $filesystem->tempnam('/tmp', 'key_');
+
+        try {
+            $filesystem->appendToFile($configFile, $backup->getBackupConfiguration()->getStorage()->getRcloneConfiguration());
+            $backupParentDirectory = \dirname($backup->getBackupConfiguration()->getRcloneBackupDir());
+            $backupDirectory = str_replace($backupParentDirectory.'/', '', $backup->getBackupConfiguration()->getRcloneBackupDir());
+
+            $command = 'rclone lsd "${REMOTE_STORAGE_DIRECTORY}" --config "${RCLONE_CONFIG}"';
+            $parameters = [
+                'REMOTE_STORAGE_DIRECTORY' => $backupParentDirectory,
+                'RCLONE_CONFIG' => $configFile,
+            ];
+
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+            $outcome = $this->processRunner->runShell($command, $parameters, self::UPLOAD_TIMEOUT);
+            $this->failOrLog($backup, $outcome, 'rclone lsd');
+
+            if (!preg_match('/\s'.preg_quote($backupDirectory, '/').'\n/', $outcome->output)) {
+                $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('INFO executing backup %s does not seems to exists', $backup->getBackupConfiguration()->getRcloneBackupDir()));
+
+                return;
+            }
+
+            $keepDays = $this->resolveKeepDays($backup);
+
+            $command = 'rclone delete --min-age "${KEEP_DAYS}d" "${REMOTE_STORAGE_BACKUP}" --config "${RCLONE_CONFIG}"';
+            $parameters = [
+                'KEEP_DAYS' => (string) $keepDays,
+                'REMOTE_STORAGE_BACKUP' => $backup->getBackupConfiguration()->getRcloneBackupDir(),
+                'RCLONE_CONFIG' => $configFile,
+            ];
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+            $outcome = $this->processRunner->runShell($command, $parameters, self::UPLOAD_TIMEOUT);
+            $this->failOrLog($backup, $outcome, 'rclone delete');
+
+            $this->pruneArchiveDirectories($backup, $configFile, $keepDays);
+
+            $command = 'rclone rmdirs "${REMOTE_STORAGE_BACKUP}" --config "${RCLONE_CONFIG}"';
+            $parameters = [
+                'REMOTE_STORAGE_BACKUP' => $backup->getBackupConfiguration()->getRcloneBackupDir(),
+                'RCLONE_CONFIG' => $configFile,
+            ];
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+            $outcome = $this->processRunner->runShell($command, $parameters, self::UPLOAD_TIMEOUT);
+            $this->failOrLog($backup, $outcome, 'rclone rmdirs');
+        } finally {
+            @unlink($configFile);
+        }
+    }
+
+    private function runRcloneCheck(Backup $backup, string $configFile): void
+    {
+        $isCrypt = preg_match('/^\s*type\s*=\s*crypt\s*$/m', (string) $backup->getBackupConfiguration()->getCompleteRcloneConfiguration());
+
+        $command = 'rclone "${CHECK}" "${SOURCE_LOCATION}" "${REMOTE_STORAGE_LOCATION}" --config "${RCLONE_CONFIG}"';
+        $parameters = [
+            'CHECK' => $isCrypt ? 'cryptcheck' : 'check',
+            'SOURCE_LOCATION' => $backup->getBackupConfiguration()->getRemotePath(),
+            'REMOTE_STORAGE_LOCATION' => $backup->getBackupConfiguration()->getStorageSubPath(),
+            'RCLONE_CONFIG' => $configFile,
+        ];
+
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, nl2br($this->backupLogger->formatParameters($parameters))));
+        $outcome = $this->processRunner->runShell($command, $parameters, self::CHECK_TIMEOUT);
+        $this->failOrLog($backup, $outcome, \sprintf('%s::healthCheck - %s', self::class, $command));
+    }
+
+    private function resolveKeepDays(Backup $backup): int
+    {
+        $keepDaily = max(0, (int) $backup->getBackupConfiguration()->getKeepDaily());
+        $keepWeekly = max(0, (int) $backup->getBackupConfiguration()->getKeepWeekly());
+
+        $keepDays = max($keepDaily, $keepWeekly * 7);
+
+        if (0 === $keepDays) {
+            $keepDays = 7;
+            $this->backupLogger->log($backup, Log::LOG_WARNING, 'Both keepDaily and keepWeekly are 0. Using default retention of 7 days.');
+        }
+
+        return $keepDays;
+    }
+
+    private function pruneArchiveDirectories(Backup $backup, string $configFile, int $keepDays): void
+    {
+        $command = 'rclone lsf "${REMOTE_STORAGE_BACKUP}" --dirs-only --config "${RCLONE_CONFIG}"';
+        $parameters = [
+            'REMOTE_STORAGE_BACKUP' => $backup->getBackupConfiguration()->getRcloneBackupDir(),
+            'RCLONE_CONFIG' => $configFile,
+        ];
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+
+        $outcome = $this->processRunner->runShell($command, $parameters, self::CHECK_TIMEOUT);
+        if (!$outcome->successful) {
+            $this->backupLogger->log($backup, Log::LOG_WARNING, \sprintf('Failed to list archive directories: %s', $outcome->errorOutput));
+
+            return;
+        }
+
+        $this->backupLogger->log($backup, Log::LOG_INFO, $outcome->output);
+        $directories = array_filter(explode("\n", trim($outcome->output)), static fn ($dir) => '' !== $dir);
+
+        $cutoffDate = new DateTime()->modify(\sprintf('-%d days', $keepDays));
+        $cutoffDate->setTime(0, 0, 0);
+
+        foreach ($directories as $directory) {
+            $directory = rtrim($directory, '/');
+            if (!preg_match('/^(\d{4}-\d{2}-\d{2})$/', $directory, $matches)) {
+                continue;
+            }
+
+            try {
+                $dirDate = DateTime::createFromFormat('!Y-m-d', $matches[1]);
+                $errors = DateTime::getLastErrors();
+
+                $hasErrors = $errors && ($errors['warning_count'] > 0 || $errors['error_count'] > 0);
+                $isValidFormat = false !== $dirDate && $dirDate->format('Y-m-d') === $matches[1];
+
+                if (!$isValidFormat || $hasErrors) {
+                    $this->backupLogger->log($backup, Log::LOG_WARNING, \sprintf('Invalid date in directory name: %s', $directory));
+                    continue;
+                }
+
+                if ($dirDate < $cutoffDate) {
+                    $archiveDir = rtrim($backup->getBackupConfiguration()->getRcloneBackupDir(), '/').'/'.$directory;
+                    $deleteCommand = 'rclone purge "${ARCHIVE_DIR}" --config "${RCLONE_CONFIG}"';
+                    $deleteParameters = [
+                        'ARCHIVE_DIR' => $archiveDir,
+                        'RCLONE_CONFIG' => $configFile,
+                    ];
+
+                    $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Attempting to delete old archive directory: %s (older than %d days retention period)', $directory, $keepDays));
+                    $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $deleteCommand, $this->backupLogger->formatParameters($deleteParameters)));
+
+                    $deleteOutcome = $this->processRunner->runShell($deleteCommand, $deleteParameters, self::CHECK_TIMEOUT);
+                    if (!$deleteOutcome->successful) {
+                        $this->backupLogger->log($backup, Log::LOG_WARNING, \sprintf('Failed to delete archive directory %s: %s', $directory, $deleteOutcome->errorOutput));
+                    } else {
+                        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Successfully deleted archive directory: %s', $directory));
+                    }
+                }
+            } catch (Exception $e) {
+                $this->backupLogger->log($backup, Log::LOG_WARNING, \sprintf('Error parsing date for directory %s: %s', $directory, $e->getMessage()));
+            }
+        }
+    }
+
+    private function failOrLog(Backup $backup, ProcessOutcome $processOutcome, string $context): void
+    {
+        if (!$processOutcome->successful) {
+            $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s - %s', $context, $processOutcome->errorOutput));
+            throw new ProcessExecutionException($processOutcome);
+        }
+        $this->backupLogger->log($backup, Log::LOG_INFO, $processOutcome->output);
+    }
+}

--- a/src/Backup/Storage/ResticStorageBackend.php
+++ b/src/Backup/Storage/ResticStorageBackend.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Storage;
+
+use App\Backup\Logging\BackupLogger;
+use App\Backup\Process\ProcessExecutionException;
+use App\Backup\Process\ProcessOutcome;
+use App\Backup\Process\ProcessRunnerInterface;
+use App\Entity\Backup;
+use App\Entity\Log;
+use App\Entity\Storage;
+use App\Utils\StringUtils;
+use DateTime;
+use Exception;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+#[AutoconfigureTag('app.backup.storage_backend')]
+class ResticStorageBackend implements StorageBackendInterface
+{
+    public const int INIT_TIMEOUT = 60;
+    public const string INIT_REGEX = '/Fatal\: create key in repository.*repository master key and config already initialized|failed\: config file already exists/';
+    public const int UPLOAD_TIMEOUT = 3600 * 4;
+    public const int CHECK_TIMEOUT = 3600;
+    public const int REPAIR_TIMEOUT = 3600;
+    public const int LOCK_MAX_AGE_SECONDS = 3600 * 20;
+    public const int SIZE_MAX_RATIO = 2;
+
+    public function __construct(
+        private readonly ProcessRunnerInterface $processRunner,
+        private readonly BackupLogger $backupLogger,
+    ) {
+    }
+
+    public function supports(Storage $storage): bool
+    {
+        return $storage->isRestic();
+    }
+
+    public function initRepository(Backup $backup): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $env = $this->buildEnv($backup);
+        $command = '(restic snapshots > /dev/null 2>&1) || restic init';
+
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s`', $command));
+        $outcome = $this->processRunner->runShell($command, $env, self::INIT_TIMEOUT);
+
+        if (!$outcome->successful && !preg_match(self::INIT_REGEX, $outcome->errorOutput)) {
+            $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $outcome->errorOutput));
+            throw new ProcessExecutionException($outcome);
+        }
+        $this->backupLogger->log($backup, Log::LOG_INFO, $outcome->output);
+    }
+
+    /**
+     * Upload a local payload to the restic repository.
+     *
+     * @param array<string, string> $tags map of tag name => value
+     */
+    public function uploadLocal(Backup $backup, string $localPath, array $tags, string $host = 'cloudbackup'): void
+    {
+        $env = $this->buildEnv($backup);
+
+        $tagFragments = [];
+        $tagParameters = [];
+        $idx = 0;
+        foreach ($tags as $tagKey => $tagValue) {
+            $placeholder = \sprintf('RESTIC_TAG_VAL_%d', $idx);
+            $tagFragments[] = \sprintf('--tag %s="${%s}"', $tagKey, $placeholder);
+            $tagParameters[$placeholder] = $tagValue;
+            ++$idx;
+        }
+
+        $command = \sprintf(
+            'restic backup %s --host %s "${DIRECTORY}"',
+            implode(' ', $tagFragments),
+            $host,
+        );
+        $parameters = $tagParameters + ['DIRECTORY' => $localPath];
+
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->backupLogger->formatParameters($parameters)));
+
+        $outcome = $this->processRunner->runShell($command, $env + $parameters, self::UPLOAD_TIMEOUT);
+        $this->failOrLog($backup, $outcome, 'restic upload');
+    }
+
+    public function healthCheck(Backup $backup, bool $tryRepair = true): void
+    {
+        $env = $this->buildEnv($backup);
+
+        $checkCommand = 'restic check';
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s`', $checkCommand));
+        $outcome = $this->processRunner->runShell($checkCommand, $env, self::CHECK_TIMEOUT);
+
+        if (!$outcome->successful) {
+            $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $checkCommand, $outcome->errorOutput));
+
+            if ($tryRepair) {
+                $this->repair($backup, $outcome->errorOutput);
+                $this->healthCheck($backup, false);
+            } else {
+                throw new ProcessExecutionException($outcome);
+            }
+        } else {
+            $this->backupLogger->log($backup, Log::LOG_INFO, $outcome->output);
+        }
+
+        $tagsClause = $backup->getBackupConfiguration()->getResticCheckTags() ? '--tag "${RESTIC_CHECK_TAG}"' : '';
+        $listCommand = \sprintf('restic snapshots --json --latest 1 -q %s', $tagsClause);
+        $listParameters = ['RESTIC_CHECK_TAG' => $backup->getBackupConfiguration()->getResticCheckTags()];
+
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $listCommand, nl2br($this->backupLogger->formatParameters($listParameters))));
+        $outcome = $this->processRunner->runShell($listCommand, $env + $listParameters, self::CHECK_TIMEOUT);
+
+        if (!$outcome->successful) {
+            $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $listCommand, $outcome->errorOutput));
+            throw new ProcessExecutionException($outcome);
+        }
+
+        $json = json_decode($outcome->output, true, 512, \JSON_THROW_ON_ERROR);
+        if (null === $json || 0 === (is_countable($json) ? \count($json) : 0)) {
+            $message = \sprintf('Cannot decode json : %s', $outcome->output);
+            $this->backupLogger->log($backup, Log::LOG_ERROR, $message);
+            throw new Exception($message);
+        }
+
+        usort($json, static fn ($a, $b) => new DateTime($b['time']) <=> new DateTime($a['time']));
+
+        $this->backupLogger->log($backup, Log::LOG_INFO, json_encode($json, \JSON_PRETTY_PRINT));
+
+        $lastBackup = new DateTime(preg_replace('/(\d+\-\d+\-\d+T\d+:\d+:\d+)\..*/', '$1', (string) $json[0]['time']));
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Last backup : %s', $lastBackup->format('d/m/Y H:i')));
+
+        if ($lastBackup < new DateTime('yesterday')) {
+            $message = 'Last backup older than 24h';
+            $this->backupLogger->log($backup, Log::LOG_ERROR, $message);
+            throw new Exception($message);
+        }
+
+        $sizes = [
+            '--mode restore-size latest' => 'resticSize',
+            '--mode raw-data latest' => 'resticDedupSize',
+            '--mode restore-size' => 'resticTotalSize',
+            '--mode raw-data' => 'resticTotalDedupSize',
+        ];
+
+        foreach ($sizes as $suffix => $attribute) {
+            $command = \sprintf('restic stats --json %s %s', $suffix, $tagsClause);
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, nl2br($this->backupLogger->formatParameters($listParameters))));
+
+            $outcome = $this->processRunner->runShell($command, $env + $listParameters, self::CHECK_TIMEOUT);
+            if (!$outcome->successful) {
+                $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $outcome->errorOutput));
+                throw new ProcessExecutionException($outcome);
+            }
+
+            $statsJson = json_decode($outcome->output, true, 512, \JSON_THROW_ON_ERROR);
+            if (null === $statsJson) {
+                $message = \sprintf('Cannot decode json : %s', $outcome->output);
+                $this->backupLogger->log($backup, Log::LOG_ERROR, $message);
+                throw new Exception($message);
+            }
+
+            $this->backupLogger->log($backup, Log::LOG_INFO, json_encode($statsJson, \JSON_PRETTY_PRINT));
+
+            PropertyAccess::createPropertyAccessor()->setValue($backup, $attribute, $statsJson['total_size']);
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Stat %s : %s', $attribute, StringUtils::humanizeFileSize($statsJson['total_size'])));
+        }
+
+        if (null === $backup->getSize()) {
+            $backup->setSize($backup->getResticSize());
+        }
+
+        $minimumBackupSize = (int) $backup->getBackupConfiguration()->getMinimumBackupSize();
+        $resticSize = (int) $backup->getResticSize();
+
+        if ($resticSize <= $minimumBackupSize) {
+            $message = \sprintf('Restic failed. Minimum backup size not met : %s < %s', StringUtils::humanizeFileSize($resticSize), StringUtils::humanizeFileSize($minimumBackupSize));
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, $message);
+            throw new Exception($message);
+        }
+
+        if ($minimumBackupSize > 0 && $resticSize > self::SIZE_MAX_RATIO * $minimumBackupSize) {
+            $newMinimumBackupSize = (int) ($minimumBackupSize * (1 + (self::SIZE_MAX_RATIO - 1) / 2));
+            $message = \sprintf('Restic backup size %s exceeds %dx the expected size %s. Updating expected size to %s.', StringUtils::humanizeFileSize($resticSize), self::SIZE_MAX_RATIO, StringUtils::humanizeFileSize($minimumBackupSize), StringUtils::humanizeFileSize($newMinimumBackupSize));
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, $message);
+            $backup->getBackupConfiguration()->setMinimumBackupSize((string) $newMinimumBackupSize);
+        }
+    }
+
+    public function prune(Backup $backup): void
+    {
+        $env = $this->buildEnv($backup);
+        $command = \sprintf('restic forget --prune %s', $backup->getBackupConfiguration()->getResticForgetArgs());
+
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s`', $command));
+        $outcome = $this->processRunner->runShell($command, $env, self::UPLOAD_TIMEOUT);
+        $this->failOrLog($backup, $outcome, 'restic forget');
+    }
+
+    public function repair(Backup $backup, ?string $errorOutput = null): void
+    {
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
+
+        $env = $this->buildEnv($backup);
+        $commands = [
+            'restic repair index',
+            'restic prune',
+            'restic check',
+        ];
+
+        if (null !== $errorOutput
+            && preg_match('/repository is already locked/m', $errorOutput)
+            && preg_match('/lock was created at .* \((\d+)h(\d+)m(\d+)\.(\d+)s ago/m', $errorOutput, $matches)
+        ) {
+            $hours = (int) $matches[1];
+            $minutes = (int) $matches[2];
+            $seconds = (int) $matches[3];
+            $totalSeconds = ($hours * 3600) + ($minutes * 60) + $seconds;
+
+            $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Repository is locked since %dh%dm%ds', $hours, $minutes, $seconds));
+
+            if ($totalSeconds > self::LOCK_MAX_AGE_SECONDS) {
+                $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Repository is locked since %dh%dm%ds which is more than the max allowed lock age of %ds', $hours, $minutes, $seconds, self::LOCK_MAX_AGE_SECONDS));
+                array_unshift($commands, 'restic unlock');
+            }
+        }
+
+        foreach ($commands as $command) {
+            $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('Run `%s`', $command));
+            $outcome = $this->processRunner->runShell($command, $env, self::REPAIR_TIMEOUT);
+            $this->failOrLog($backup, $outcome, \sprintf('%s::%s - %s', self::class, __FUNCTION__, $command));
+        }
+    }
+
+    /** @return array<string, scalar|null> */
+    private function buildEnv(Backup $backup): array
+    {
+        return $backup->getBackupConfiguration()->getStorage()->getEnv()
+            + $backup->getBackupConfiguration()->getResticEnv();
+    }
+
+    private function failOrLog(Backup $backup, ProcessOutcome $processOutcome, string $context): void
+    {
+        if (!$processOutcome->successful) {
+            $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s - %s', $context, $processOutcome->errorOutput));
+            throw new ProcessExecutionException($processOutcome);
+        }
+        $this->backupLogger->log($backup, Log::LOG_INFO, $processOutcome->output);
+    }
+}

--- a/src/Backup/Storage/StorageBackendInterface.php
+++ b/src/Backup/Storage/StorageBackendInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Storage;
+
+use App\Entity\Backup;
+use App\Entity\Storage;
+
+interface StorageBackendInterface
+{
+    public function supports(Storage $storage): bool;
+
+    public function initRepository(Backup $backup): void;
+
+    public function healthCheck(Backup $backup, bool $tryRepair = true): void;
+
+    public function prune(Backup $backup): void;
+}

--- a/src/Backup/Storage/StorageBackendRegistry.php
+++ b/src/Backup/Storage/StorageBackendRegistry.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Storage;
+
+use App\Entity\Storage;
+use RuntimeException;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+class StorageBackendRegistry
+{
+    /** @var iterable<StorageBackendInterface> */
+    private readonly iterable $backends;
+
+    /** @param iterable<StorageBackendInterface> $backends */
+    public function __construct(
+        #[AutowireIterator('app.backup.storage_backend')]
+        iterable $backends,
+    ) {
+        $this->backends = $backends;
+    }
+
+    public function forStorage(Storage $storage): StorageBackendInterface
+    {
+        foreach ($this->backends as $backend) {
+            if ($backend->supports($storage)) {
+                return $backend;
+            }
+        }
+
+        throw new RuntimeException(\sprintf('No storage backend supports storage type "%s"', (string) $storage->getType()));
+    }
+}

--- a/src/EventSubscriber/BackupSubscriber.php
+++ b/src/EventSubscriber/BackupSubscriber.php
@@ -1,22 +1,30 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\EventSubscriber;
 
+use App\Backup\Logging\BackupLogger;
+use App\Backup\Source\BackupSourceInterface;
+use App\Backup\Source\BackupSourceRegistry;
+use App\Backup\Storage\StorageBackendRegistry;
 use App\Entity\Backup;
 use App\Entity\BackupConfiguration;
 use App\Entity\Log;
 use App\Repository\BackupRepository;
-use App\Service\BackupService;
 use App\Service\MailerService;
 use Exception;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Workflow\Event\Event;
 use Symfony\Component\Workflow\Event\GuardEvent;
+use Throwable;
 
-class BackupSubscriber implements EventSubscriberInterface
+final class BackupSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly BackupService $backupService,
+        private readonly BackupSourceRegistry $sourceRegistry,
+        private readonly StorageBackendRegistry $storageRegistry,
+        private readonly BackupLogger $backupLogger,
         private readonly MailerService $mailerService,
         private readonly BackupRepository $backupRepository,
     ) {
@@ -24,245 +32,227 @@ class BackupSubscriber implements EventSubscriberInterface
 
     public function onStart(Event $event): void
     {
-        /** @var Backup */
-        $backup = $event->getSubject();
+        $backup = $this->extractBackup($event);
+        $storage = $backup->getBackupConfiguration()->getStorage();
 
-        if ($backup->getBackupConfiguration()->getStorage()->isRestic()) {
-            $this->backupService->resticInitRepo($backup);
-        } elseif ($backup->getBackupConfiguration()->getStorage()->isRclone()) {
-            // Nothing to do
-        } else {
-            $this->backupService->log($backup, Log::LOG_INFO, \sprintf('%s : Nothing to do', $backup->getCurrentPlace()));
+        if ($storage->isRestic()) {
+            $this->storageRegistry->forStorage($storage)->initRepository($backup);
+
+            return;
         }
+
+        if ($storage->isRclone()) {
+            return;
+        }
+
+        $this->backupLogger->log($backup, Log::LOG_INFO, \sprintf('%s : Nothing to do', $backup->getCurrentPlace()));
     }
 
     public function onDump(Event $event): void
     {
-        /** @var Backup */
-        $backup = $event->getSubject();
-
-        match ($backup->getBackupConfiguration()->getType()) {
-            BackupConfiguration::TYPE_OS_INSTANCE => $this->backupService->snapshotOSInstance($backup),
-            default => $this->backupService->log($backup, Log::LOG_INFO, \sprintf('%s : Nothing to do', $backup->getCurrentPlace())),
-        };
+        $backup = $this->extractBackup($event);
+        $this->sourceFor($backup)->onDump($backup);
     }
 
     public function onDownload(Event $event): void
     {
-        /** @var Backup */
-        $backup = $event->getSubject();
-
-        $this->backupService->downloadBackup($backup);
+        $backup = $this->extractBackup($event);
+        $this->sourceFor($backup)->download($backup);
     }
 
     public function onUpload(Event $event): void
     {
-        /** @var Backup */
-        $backup = $event->getSubject();
-
-        $this->backupService->uploadBackup($backup);
+        $backup = $this->extractBackup($event);
+        $this->sourceFor($backup)->upload($backup);
     }
 
     public function onCleanup(Event $event): void
     {
-        /** @var Backup */
-        $backup = $event->getSubject();
-
-        $this->backupService->cleanBackup($backup);
+        $backup = $this->extractBackup($event);
+        $this->sourceFor($backup)->cleanupLocal($backup);
     }
 
     public function onHealthCheck(Event $event): void
     {
-        /** @var Backup */
-        $backup = $event->getSubject();
-
-        $this->backupService->healhCheckBackup($backup, true);
+        $backup = $this->extractBackup($event);
+        $this->storageRegistry->forStorage($backup->getBackupConfiguration()->getStorage())
+            ->healthCheck($backup, true);
     }
 
     public function onForget(Event $event): void
     {
-        /** @var Backup */
-        $backup = $event->getSubject();
+        $backup = $this->extractBackup($event);
+        $configuration = $backup->getBackupConfiguration();
+        $storage = $configuration->getStorage();
 
-        // Restic forget
-        if ($backup->getBackupConfiguration()->getStorage()->isRestic() && BackupConfiguration::TYPE_READ_RESTIC !== $backup->getBackupConfiguration()->getType()) {
-            $this->backupService->cleanBackupRestic($backup);
+        if ($storage->isRestic() && BackupConfiguration::TYPE_READ_RESTIC !== $configuration->getType()) {
+            $this->storageRegistry->forStorage($storage)->prune($backup);
         }
 
-        // Rclone forget
-        if ($backup->getBackupConfiguration()->getStorage()->isRclone()) {
-            $this->backupService->cleanBackupRclone($backup);
+        if ($storage->isRclone()) {
+            $this->storageRegistry->forStorage($storage)->prune($backup);
         }
     }
 
     public function onFailed(Event $event): void
     {
-        /** @var Backup */
-        $backup = $event->getSubject();
+        $backup = $this->extractBackup($event);
+        $this->backupLogger->log($backup, Log::LOG_ERROR, 'Backup failed');
 
-        $this->backupService->log($backup, Log::LOG_ERROR, 'Backup failed');
+        $notifyEvery = $backup->getBackupConfiguration()->getNotifyEvery();
+        if ($notifyEvery <= 0) {
+            return;
+        }
 
         $countFailedBackupsSinceLastSuccess = $this->backupRepository->countFailedBackupsSinceLastSuccess($backup);
-        $notifyEvery = $backup->getBackupConfiguration()->getNotifyEvery();
-
-        // Notify every X failed backups, and do not notify if notifyEvery is 0
-        if ($backup->getBackupConfiguration()->getNotifyEvery() > 0 && 0 === ($countFailedBackupsSinceLastSuccess + 1) % $notifyEvery) {
+        if (0 === ($countFailedBackupsSinceLastSuccess + 1) % $notifyEvery) {
             $this->mailerService->sendFailedBackupReport($backup);
         }
     }
 
     public function onEnterAll(Event $event): void
     {
-        /** @var Backup */
-        $backup = $event->getSubject();
-
-        $this->backupService->log($backup, Log::LOG_INFO, \sprintf('Transition %s from %s to %s', $backup->getBackupConfiguration()->getName(), $backup->getCurrentPlace(), $event->getTransition()->getName()));
+        $backup = $this->extractBackup($event);
+        $this->backupLogger->log(
+            $backup,
+            Log::LOG_INFO,
+            \sprintf(
+                'Transition %s from %s to %s',
+                $backup->getBackupConfiguration()->getName(),
+                $backup->getCurrentPlace(),
+                $event->getTransition()->getName(),
+            ),
+        );
     }
 
     public function guardStart(GuardEvent $guardEvent): void
     {
-        /** @var Backup */
-        $backup = $guardEvent->getSubject();
+        $backup = $this->extractBackup($guardEvent);
+        $notBefore = $backup->getBackupConfiguration()->getNotBefore();
 
-        if ($backup->getBackupConfiguration()->getNotBefore() > date('H')) {
-            $message = \sprintf('Cannot start backup before %s', $backup->getBackupConfiguration()->getNotBefore());
-
-            $this->backupService->log(
-                $backup,
-                Log::LOG_NOTICE,
-                $message
-            );
+        if (null !== $notBefore && $notBefore > (int) date('H')) {
+            $message = \sprintf('Cannot start backup before %s', $notBefore);
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, $message);
             $guardEvent->setBlocked(true, $message);
         }
     }
 
     public function guardDownload(GuardEvent $guardEvent): void
     {
-        /** @var Backup */
-        $backup = $guardEvent->getSubject();
+        $backup = $this->extractBackup($guardEvent);
+        $source = $this->sourceFor($backup);
 
         try {
-            switch ($backup->getBackupConfiguration()->getType()) {
-                case BackupConfiguration::TYPE_OS_INSTANCE:
-                    $status = $this->backupService->getSnapshotOsInstanceStatus($backup);
-                    if (null === $status) {
-                        $message = 'Snaphot not found';
+            if (BackupConfiguration::TYPE_OS_INSTANCE !== $backup->getBackupConfiguration()->getType()) {
+                return;
+            }
 
-                        $guardEvent->setBlocked(true, $message);
-                        $this->backupService->log($backup, Log::LOG_WARNING, $message);
-                    } elseif ('active' !== $status) {
-                        $message = \sprintf('Snapshot not ready : %s', $status);
+            $status = $source->getSnapshotStatus($backup);
+            if (null === $status) {
+                $message = 'Snapshot not found';
+                $guardEvent->setBlocked(true, $message);
+                $this->backupLogger->log($backup, Log::LOG_WARNING, $message);
 
-                        $guardEvent->setBlocked(true, $message);
-                        $this->backupService->log($backup, Log::LOG_NOTICE, $message);
-                    }
-                    break;
-                default:
-                    break;
+                return;
+            }
+
+            if ('active' !== $status) {
+                $message = \sprintf('Snapshot not ready : %s', $status);
+                $guardEvent->setBlocked(true, $message);
+                $this->backupLogger->log($backup, Log::LOG_NOTICE, $message);
             }
         } catch (Exception $e) {
-            $this->backupService->log($backup, Log::LOG_WARNING, \sprintf('Guard download error : %s', $e->getMessage()));
-
+            $this->backupLogger->log($backup, Log::LOG_WARNING, \sprintf('Guard download error : %s', $e->getMessage()));
             $guardEvent->setBlocked(true, $e->getMessage());
         }
     }
 
     public function guardUpload(GuardEvent $guardEvent): void
     {
-        /** @var Backup */
-        $backup = $guardEvent->getSubject();
+        $backup = $this->extractBackup($guardEvent);
+        $source = $this->sourceFor($backup);
 
         try {
-            switch ($backup->getBackupConfiguration()->getType()) {
-                case BackupConfiguration::TYPE_OS_INSTANCE:
-                    if (!$this->backupService->checkDownloadedOSSnapshot($backup)) {
-                        $message = 'Download not completed';
-
-                        $guardEvent->setBlocked(true, $message);
-                        $this->backupService->log($backup, Log::LOG_WARNING, $message);
-                    }
-                    break;
-                case BackupConfiguration::TYPE_SSHFS:
-                    if (!$this->backupService->checkDownloadedFUSE($backup)) {
-                        $message = 'Download not completed';
-
-                        $guardEvent->setBlocked(true, $message);
-                        $this->backupService->log($backup, Log::LOG_WARNING, $message);
-                    }
-                    break;
-                case BackupConfiguration::TYPE_MYSQL:
-                case BackupConfiguration::TYPE_POSTGRESQL:
-                case BackupConfiguration::TYPE_SQL_SERVER:
-                case BackupConfiguration::TYPE_SSH_CMD:
-                case BackupConfiguration::TYPE_SFTP:
-                    if (!$this->backupService->checkDownloadedDump($backup)) {
-                        $message = 'Download not completed';
-
-                        $guardEvent->setBlocked(true, $message);
-                        $this->backupService->log($backup, Log::LOG_WARNING, $message);
-                    }
-                    break;
-                default:
-                    break;
+            if (!$source->isDownloadComplete($backup)) {
+                $message = 'Download not completed';
+                $guardEvent->setBlocked(true, $message);
+                $this->backupLogger->log($backup, Log::LOG_WARNING, $message);
             }
         } catch (Exception $e) {
-            $this->backupService->log($backup, Log::LOG_ERROR, \sprintf('Guard upload error : %s', $e->getMessage()));
-
+            $this->backupLogger->log($backup, Log::LOG_ERROR, \sprintf('Guard upload error : %s', $e->getMessage()));
             $guardEvent->setBlocked(true, $e->getMessage());
         }
     }
 
     public function guardCleanup(GuardEvent $guardEvent): void
     {
-        // Nothing to do
+        // No precondition.
     }
 
-    public function guardHealhCheck(GuardEvent $guardEvent): void
+    public function guardHealthCheck(GuardEvent $guardEvent): void
     {
-        /** @var Backup */
-        $backup = $guardEvent->getSubject();
+        $backup = $this->extractBackup($guardEvent);
+        $source = $this->sourceFor($backup);
 
-        if (!$this->backupService->isBackupCleaned($backup)) {
+        try {
+            $isCleaned = $source->isLocallyCleaned($backup);
+        } catch (Throwable $e) {
+            $this->backupLogger->log($backup, Log::LOG_WARNING, \sprintf('Guard health check error : %s', $e->getMessage()));
+            $guardEvent->setBlocked(true, $e->getMessage());
+
+            return;
+        }
+
+        if (!$isCleaned) {
             $message = 'Temporary backup still exists';
-
             $guardEvent->setBlocked(true, $message);
-            $this->backupService->log($backup, Log::LOG_ERROR, $message);
+            $this->backupLogger->log($backup, Log::LOG_ERROR, $message);
 
-            // We retry the cleanup
-            $this->backupService->cleanBackup($backup);
+            try {
+                $source->cleanupLocal($backup);
+            } catch (Throwable $cleanupError) {
+                $this->backupLogger->log($backup, Log::LOG_WARNING, \sprintf('Retry cleanup failed: %s', $cleanupError->getMessage()));
+            }
         }
     }
 
     public function guardForget(GuardEvent $guardEvent): void
     {
-        /** @var Backup */
-        $backup = $guardEvent->getSubject();
+        $backup = $this->extractBackup($guardEvent);
+        $storage = $backup->getBackupConfiguration()->getStorage();
 
-        if ($backup->getBackupConfiguration()->getStorage()->isRestic() && (null === $backup->getResticSize() || 0 === $backup->getResticSize())) {
-            $message = 'Restic size not set from health check. Retry health check';
+        if ($storage->isRestic() && (null === $backup->getResticSize() || 0 === $backup->getResticSize())) {
+            $this->retryHealthCheck($backup, $guardEvent, 'Restic size not set from health check. Retry health check');
 
-            $guardEvent->setBlocked(true, $message);
-            $this->backupService->log($backup, Log::LOG_ERROR, $message);
+            return;
+        }
 
-            // We retry the health check
-            $this->backupService->healhCheckBackup($backup);
-        } elseif ($backup->getBackupConfiguration()->getStorage()->isRclone() && (null === $backup->getSize() || 0 === $backup->getSize())) {
-            $message = 'Rclone size not set from health check. Retry health check';
+        if ($storage->isRclone() && (null === $backup->getSize() || 0 === $backup->getSize())) {
+            $this->retryHealthCheck($backup, $guardEvent, 'Rclone size not set from health check. Retry health check');
+        }
+    }
 
-            $guardEvent->setBlocked(true, $message);
-            $this->backupService->log($backup, Log::LOG_ERROR, $message);
+    private function retryHealthCheck(Backup $backup, GuardEvent $guardEvent, string $message): void
+    {
+        $guardEvent->setBlocked(true, $message);
+        $this->backupLogger->log($backup, Log::LOG_ERROR, $message);
 
-            // We retry the health check
-            $this->backupService->healhCheckBackup($backup);
+        try {
+            $this->storageRegistry->forStorage($backup->getBackupConfiguration()->getStorage())
+                ->healthCheck($backup, true);
+        } catch (Throwable $retryError) {
+            $this->backupLogger->log($backup, Log::LOG_WARNING, \sprintf('Retry health check failed: %s', $retryError->getMessage()));
         }
     }
 
     public function onGuardAll(GuardEvent $guardEvent): void
     {
-        /** @var Backup */
-        $backup = $guardEvent->getSubject();
-
-        $this->backupService->log($backup, Log::LOG_INFO, \sprintf('GuardAll from %s to %s', $backup->getCurrentPlace(), $guardEvent->getTransition()->getName()));
+        $backup = $this->extractBackup($guardEvent);
+        $this->backupLogger->log(
+            $backup,
+            Log::LOG_INFO,
+            \sprintf('GuardAll from %s to %s', $backup->getCurrentPlace(), $guardEvent->getTransition()->getName()),
+        );
     }
 
     public static function getSubscribedEvents(): array
@@ -283,10 +273,23 @@ class BackupSubscriber implements EventSubscriberInterface
             'workflow.backup.guard.download' => 'guardDownload',
             'workflow.backup.guard.upload' => 'guardUpload',
             'workflow.backup.guard.cleanup' => 'guardCleanup',
-            'workflow.backup.guard.health_check' => 'guardHealhCheck',
+            'workflow.backup.guard.health_check' => 'guardHealthCheck',
             'workflow.backup.guard.forget' => 'guardForget',
 
             'workflow.backup.guard' => 'onGuardAll',
         ];
+    }
+
+    private function extractBackup(Event $event): Backup
+    {
+        $subject = $event->getSubject();
+        \assert($subject instanceof Backup);
+
+        return $subject;
+    }
+
+    private function sourceFor(Backup $backup): BackupSourceInterface
+    {
+        return $this->sourceRegistry->forConfiguration($backup->getBackupConfiguration());
     }
 }

--- a/src/Service/BackupService.php
+++ b/src/Service/BackupService.php
@@ -1,83 +1,151 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service;
 
+use App\Backup\Logging\BackupLogger;
 use App\Entity\Backup;
 use App\Entity\BackupConfiguration;
-use App\Entity\Host;
 use App\Entity\Log;
-use App\Entity\Storage;
 use App\Repository\BackupRepository;
-use App\Utils\StringUtils;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
-use InvalidArgumentException;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\Process;
-use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Workflow\Registry;
+use Symfony\Component\Workflow\WorkflowInterface;
 
-class BackupService
+final class BackupService
 {
-    final public const int RESTIC_INIT_TIMEOUT = 60;
-    final public const string RESTIC_INIT_REGEX = '/Fatal\: create key in repository.*repository master key and config already initialized|failed\: config file already exists/';
-    final public const RESTIC_UPLOAD_TIMEOUT = 3600 * 4;
-    final public const int RESTIC_CHECK_TIMEOUT = 3600;
-    final public const int RESTIC_REPAIR_TIMEOUT = 3600;
-    final public const int RESTIC_LOCK_MAX_AGE_SECONDS = 3600 * 20;
-
-    final public const int OS_INSTANCE_SNAPSHOT_TIMEOUT = 60;
-    final public const int OS_IMAGE_LIST_TIMEOUT = 60;
-    final public const OS_DOWNLOAD_TIMEOUT = 3600 * 4;
-
-    final public const int SSHFS_MOUNT_TIMEOUT = 60;
-    final public const int SSHFS_UMOUNT_TIMEOUT = 60;
-
-    final public const DOWNLOAD_SIZE_TIMEOUT = 60 * 10;
-
-    final public const RCLONE_UPLOAD_TIMEOUT = 3600 * 4;
-    final public const int RCLONE_CHECK_TIMEOUT = 3600;
-
-    final public const int KOPIA_CHECK_TIMEOUT = 3600;
-
-    final public const int BACKUP_SIZE_MAX_RATIO = 2;
-
     public function __construct(
-        private readonly string $temporaryDownloadDirectory,
-        private readonly LoggerInterface $logger,
         private readonly EntityManagerInterface $entityManager,
         private readonly Registry $workflowRegistry,
         private readonly BackupRepository $backupRepository,
+        private readonly BackupLogger $backupLogger,
     ) {
     }
 
-    public function log(Backup $backup, string $level, string $message): void
+    public function initBackup(BackupConfiguration $backupConfiguration): void
     {
-        match ($level) {
-            Log::LOG_ERROR => $this->logger->error($message),
-            Log::LOG_WARNING => $this->logger->warning($message),
-            Log::LOG_INFO => $this->logger->info($message),
-            Log::LOG_NOTICE => $this->logger->notice($message),
-            default => throw new Exception('Log level not found'),
-        };
+        $now = new DateTime();
+        $backup = $this->findOrCreateBackup($backupConfiguration);
 
-        $log = new Log();
-        $log->setLevel($level);
-        $log->setMessage($message);
+        if ($this->isTerminalForToday($backup, $backupConfiguration, $now)) {
+            return;
+        }
 
-        $backup->addLog($log);
+        $workflow = $this->workflowRegistry->get($backup);
 
-        $this->entityManager->persist($log);
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s. CurrentState : %s', self::class, __FUNCTION__, $backup->getCurrentPlace()));
+
+        if ('backuped' === $backup->getCurrentPlace()) {
+            $backup = new Backup();
+            $backup->setBackupConfiguration($backupConfiguration);
+        } elseif ('initialized' !== $backup->getCurrentPlace()) {
+            $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('Resume backup with current state %s', $backup->getCurrentPlace()));
+
+            $isStale = $backup->getCreatedAt()->format('Y-m-d') !== $now->format('Y-m-d')
+                && BackupConfiguration::PERIODICITY_DAILY === $backupConfiguration->getPeriodicity();
+
+            if ($isStale) {
+                $this->backupLogger->log($backup, Log::LOG_NOTICE, 'Backup is not from today, force fail it');
+                if ('failed' !== $backup->getCurrentPlace()) {
+                    $workflow->apply($backup, 'failed');
+                    $this->entityManager->persist($backup);
+                    $this->entityManager->flush();
+                }
+
+                $backup = new Backup();
+                $backup->setBackupConfiguration($backupConfiguration);
+            }
+        }
+
+        try {
+            if ($workflow->can($backup, 'start')) {
+                $workflow->apply($backup, 'start');
+            }
+
+            if ($workflow->can($backup, 'upload')) {
+                $workflow->apply($backup, 'upload');
+            } elseif ($workflow->can($backup, 'dump')) {
+                $workflow->apply($backup, 'dump');
+            }
+        } catch (Exception $e) {
+            $this->failWorkflow($backup, $workflow, $e);
+        }
+
         $this->entityManager->persist($backup);
         $this->entityManager->flush();
     }
 
-    public function logParameters(mixed $parameters): string
+    public function performBackup(BackupConfiguration $backupConfiguration): void
     {
-        return strip_tags(json_encode($parameters, \JSON_PRETTY_PRINT));
+        $backup = $this->findLatestBackupOrFail($backupConfiguration);
+
+        if ($this->isTerminalForToday($backup, $backupConfiguration, new DateTime())) {
+            return;
+        }
+
+        $workflow = $this->workflowRegistry->get($backup);
+
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s. CurrentState : %s', self::class, __FUNCTION__, $backup->getCurrentPlace()));
+
+        try {
+            foreach (['download', 'upload', 'cleanup'] as $transition) {
+                if ($workflow->can($backup, $transition)) {
+                    $workflow->apply($backup, $transition);
+                }
+            }
+        } catch (Exception $e) {
+            $this->failWorkflow($backup, $workflow, $e);
+        }
+
+        $this->entityManager->persist($backup);
+        $this->entityManager->flush();
+    }
+
+    public function completeBackup(BackupConfiguration $backupConfiguration): void
+    {
+        $backup = $this->findLatestBackupOrFail($backupConfiguration);
+
+        if ($this->isTerminalForToday($backup, $backupConfiguration, new DateTime())) {
+            return;
+        }
+
+        $workflow = $this->workflowRegistry->get($backup);
+
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s. CurrentState : %s', self::class, __FUNCTION__, $backup->getCurrentPlace()));
+
+        try {
+            foreach (['health_check', 'forget', 'backuped'] as $transition) {
+                if ($workflow->can($backup, $transition)) {
+                    $workflow->apply($backup, $transition);
+                }
+            }
+        } catch (Exception $e) {
+            $this->failWorkflow($backup, $workflow, $e);
+        }
+
+        $this->entityManager->persist($backup);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * A backup in a terminal place (failed/backuped) for today's daily run is "done":
+     * the hourly poller should skip it silently rather than re-entering the workflow
+     * and emitting a NOTICE log line each pass.
+     */
+    private function isTerminalForToday(Backup $backup, BackupConfiguration $backupConfiguration, DateTime $now): bool
+    {
+        if (BackupConfiguration::PERIODICITY_DAILY !== $backupConfiguration->getPeriodicity()) {
+            return false;
+        }
+
+        if (!\in_array($backup->getCurrentPlace(), ['failed', 'backuped'], true)) {
+            return false;
+        }
+
+        return $backup->getCreatedAt()?->format('Y-m-d') === $now->format('Y-m-d');
     }
 
     public function applyWorkflow(Backup $backup, string $transition): void
@@ -89,1655 +157,41 @@ class BackupService
         $this->entityManager->flush();
     }
 
-    public function snapshotOSInstance(Backup $backup): void
+    private function findOrCreateBackup(BackupConfiguration $backupConfiguration): Backup
     {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        $status = $this->getSnapshotOsInstanceStatus($backup);
-        if (null !== $status) {
-            $this->log($backup, Log::LOG_NOTICE, \sprintf('Snapshot already found with %s', $status));
-
-            return;
-        }
-
-        $env = $backup->getBackupConfiguration()->getOsInstance()->getOSEnv();
-
-        $command = 'openstack server image create --name ${BACKUP_NAME} ${OS_INSTANCE_ID}';
-        $parameters = [
-            'BACKUP_NAME' => $backup->getName(),
-            'OS_INSTANCE_ID' => $backup->getBackupConfiguration()->getOsInstance()->getId(),
-        ];
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-        $process = Process::fromShellCommandline($command, null, $env + $parameters);
-        $process->setTimeout(self::OS_INSTANCE_SNAPSHOT_TIMEOUT);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - openstack server image create - %s', $process->getErrorOutput()));
-            throw new ProcessFailedException($process);
-        } else {
-            $this->log($backup, Log::LOG_INFO, $process->getOutput());
-        }
-    }
-
-    public function getSnapshotOsInstanceStatus(Backup $backup): ?string
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        $env = $backup->getBackupConfiguration()->getOsInstance()->getOSEnv();
-
-        $command = 'openstack image list --private --name ${BACKUP_NAME} --long -f json';
-        $parameters = [
-            'BACKUP_NAME' => $backup->getName(),
-        ];
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-        $process = Process::fromShellCommandline($command, null, $env + $parameters);
-        $process->setTimeout(self::OS_IMAGE_LIST_TIMEOUT);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing snapshot - openstack image list - %s', $process->getErrorOutput()));
-            throw new ProcessFailedException($process);
-        } else {
-            $this->log($backup, Log::LOG_INFO, $process->getOutput());
-        }
-
-        $output = json_decode($process->getOutput(), true, 512, \JSON_THROW_ON_ERROR);
-        if (null === $output) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing snapshot - openstack image list - %s - %s', $process->getOutput(), $process->getErrorOutput()));
-            throw new ProcessFailedException($process);
-        }
-
-        if ((is_countable($output) ? \count($output) : 0) === 0) {
-            return null;
-        }
-
-        if (null === $backup->getOsImageId() || null === $backup->getSize()) {
-            $backup->setOsImageId($output[0]['ID']);
-            $backup->setChecksum($output[0]['Checksum']);
-            $backup->setSize($output[0]['Size']);
-        }
-
-        $this->entityManager->persist($backup);
-        $this->entityManager->flush();
-
-        return $output[0]['Status'];
-    }
-
-    private function getSftpDownloadSize(Backup $backup): int
-    {
-        $command = 'du -sb "${BACKUP_DESTINATION}" | cut -f1';
-        $parameters = [
-            'BACKUP_DESTINATION' => $this->getTemporaryBackupDestination($backup),
-        ];
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-        $process = Process::fromShellCommandline($command, null, $parameters);
-        $process->setTimeout(self::DOWNLOAD_SIZE_TIMEOUT);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error getting download size - %s', $process->getErrorOutput()));
-            throw new ProcessFailedException($process);
-        } else {
-            $this->log($backup, Log::LOG_INFO, $process->getOutput());
-        }
-
-        return (int) $process->getOutput();
-    }
-
-    private function downloadOSSnapshot(Backup $backup): void
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        $env = $backup->getBackupConfiguration()->getOsInstance()->getOSEnv();
-
-        if (!$backup->getOsImageId()) {
-            $command = 'openstack image list --private --name ${BACKUP_NAME} --long -f json';
-            $parameters = [
-                'BACKUP_NAME' => $backup->getName(),
-            ];
-
-            $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-            $process = Process::fromShellCommandline($command, null, $env + $parameters);
-            $process->setTimeout(self::OS_IMAGE_LIST_TIMEOUT);
-            $process->run();
-
-            if (!$process->isSuccessful()) {
-                $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing download - openstack image list - %s', $process->getErrorOutput()));
-                throw new ProcessFailedException($process);
-            } else {
-                $this->log($backup, Log::LOG_INFO, $process->getOutput());
-            }
-
-            $output = json_decode($process->getOutput(), true, 512, \JSON_THROW_ON_ERROR);
-            if (null === $output) {
-                $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing download - openstack image list - %s - %s', $process->getOutput(), $process->getErrorOutput()));
-                throw new ProcessFailedException($process);
-            }
-
-            if ((is_countable($output) ? \count($output) : 0) === 0) {
-                return;
-            }
-
-            $backup->setOsImageId($output[0]['ID']);
-            $backup->setChecksum($output[0]['Checksum']);
-            $backup->setSize($output[0]['Size']);
-
-            $this->entityManager->persist($backup);
-            $this->entityManager->flush();
-        }
-
-        $imageDestination = $this->getTemporaryBackupDestination($backup);
-
-        if (file_exists($imageDestination) && filesize($imageDestination) === $backup->getSize()) {
-            $this->log($backup, Log::LOG_NOTICE, 'Openstack image already downloaded');
-
-            return;
-        }
-
-        $command = 'openstack image save --file ${IMAGE_DESTINATION} ${IMAGE_ID}';
-        $parameters = [
-            'IMAGE_DESTINATION' => $imageDestination,
-            'IMAGE_ID' => $backup->getOsImageId(),
-        ];
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-        $process = Process::fromShellCommandline($command, null, $env + $parameters);
-        $process->setTimeout(self::OS_DOWNLOAD_TIMEOUT);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing download - openstack image save - %s', $process->getErrorOutput()));
-            $this->cleanBackupOsInstance($backup);
-            @unlink($imageDestination);
-            throw new ProcessFailedException($process);
-        } else {
-            $this->log($backup, Log::LOG_INFO, $process->getOutput());
-        }
-
-        $this->log($backup, Log::LOG_NOTICE, 'Openstack image downloaded');
-    }
-
-    private function downloadCommandResult(Backup $backup): void
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        $filesystem = new Filesystem();
-        $backupDestination = $this->getTemporaryBackupDestination($backup);
-
-        if (null !== $backup->getBackupConfiguration()->getHost()) {
-            if (null !== $backup->getBackupConfiguration()->getHost()->getPrivateKey()) {
-                $privateKeypath = $filesystem->tempnam('/tmp', 'key_');
-                $filesystem->appendToFile($privateKeypath, str_replace("\r", '', $backup->getBackupConfiguration()->getHost()->getPrivateKey()."\n"));
-                $privateKeyString = '-i ${PRIVATE_KEY_PATH}';
-            }
-
-            if (null !== $backup->getBackupConfiguration()->getHost()->getPassword()) {
-                $sshpass = 'sshpass -p ${SSHPASS}';
-            }
-
-            $sshOptions = $this->buildSshOptionsString($backup->getBackupConfiguration()->getHost());
-
-            $command = \sprintf(
-                '%s ssh "${LOGIN}@${IP}" -p "${PORT}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null%s %s "${DUMP_COMMAND} | gzip -9" | gunzip > "${DESTINATION}"',
-                $sshpass ?? null,
-                $sshOptions,
-                $privateKeyString ?? null
-            );
-            $parameters = [
-                'SSHPASS' => $backup->getBackupConfiguration()->getHost()->getPassword(),
-                'LOGIN' => $backup->getBackupConfiguration()->getHost()->getLogin(),
-                'IP' => $backup->getBackupConfiguration()->getHost()->getIp(),
-                'PORT' => $backup->getBackupConfiguration()->getHost()->getPort() ?? 22,
-                'PRIVATE_KEY_PATH' => $privateKeypath ?? null,
-                'DUMP_COMMAND' => $backup->getBackupConfiguration()->getDumpCommand(),
-                'DESTINATION' => $backupDestination,
-            ];
-        } else {
-            $command = 'sh -c "${DUMP_COMMAND}" > "${DESTINATION}"';
-            $parameters = [
-                'DUMP_COMMAND' => $backup->getBackupConfiguration()->getDumpCommand(),
-                'DESTINATION' => $backupDestination,
-            ];
-        }
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-        $process = Process::fromShellCommandline($command, null, $parameters);
-        $process->setTimeout(self::OS_DOWNLOAD_TIMEOUT);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing download - exec dump command - %s', $process->getErrorOutput()));
-            throw new ProcessFailedException($process);
-        } else {
-            $this->log($backup, Log::LOG_INFO, $process->getOutput());
-        }
-
-        $backup->setSize(filesize($backupDestination));
-        $this->log($backup, Log::LOG_INFO, \sprintf('Backup size : %s', StringUtils::humanizeFileSize($backup->getSize())));
-
-        $this->log($backup, Log::LOG_NOTICE, 'Dump done');
-    }
-
-    private function downloadKubeCommandResult(Backup $backup): void
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        $filesystem = new Filesystem();
-        $backupDestination = $this->getTemporaryBackupDestination($backup);
-
-        $kubeconfigPath = $filesystem->tempnam('/tmp', 'kubeconfig_');
-        $filesystem->appendToFile($kubeconfigPath, str_replace("\r", '', $backup->getBackupConfiguration()->getKubeconfig()->getKubeconfig()."\n"));
-
-        $command = 'kubectl --kubeconfig ${KUBECONFIG_PATH} --namespace ${KUBE_NAMESPACE} exec --tty=false ${KUBE_RESOURCE} -- ${DUMP_COMMAND} > "${DESTINATION}"';
-        $parameters = [
-            'KUBECONFIG_PATH' => $kubeconfigPath,
-            'KUBE_NAMESPACE' => $backup->getBackupConfiguration()->getKubeNamespace(),
-            'KUBE_RESOURCE' => $backup->getBackupConfiguration()->getKubeResource(),
-            'DUMP_COMMAND' => $backup->getBackupConfiguration()->getDumpCommand(),
-            'DESTINATION' => $backupDestination,
-        ];
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-        $process = Process::fromShellCommandline($command, null, $parameters);
-        $process->setTimeout(self::OS_DOWNLOAD_TIMEOUT);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing download - exec dump command - %s', $process->getErrorOutput()));
-            throw new ProcessFailedException($process);
-        } else {
-            $this->log($backup, Log::LOG_INFO, $process->getOutput());
-        }
-
-        $backup->setSize(filesize($backupDestination));
-        $this->log($backup, Log::LOG_INFO, \sprintf('Backup size : %s', StringUtils::humanizeFileSize($backup->getSize())));
-
-        $this->log($backup, Log::LOG_NOTICE, 'Dump done');
-    }
-
-    private function downloadSSHFS(Backup $backup): void
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        if (!$this->checkDownloadedFUSE($backup)) {
-            $filesystem = new Filesystem();
-
-            $backupDestination = $this->getTemporaryBackupDestination($backup);
-            $filesystem->mkdir($backupDestination);
-
-            if (null !== $backup->getBackupConfiguration()->getHost()->getPrivateKey()) {
-                $privateKeypath = $filesystem->tempnam('/tmp', 'key_');
-                $filesystem->appendToFile($privateKeypath, str_replace("\r", '', $backup->getBackupConfiguration()->getHost()->getPrivateKey()."\n"));
-                $privateKeyString = '-o IdentityFile="${PRIVATE_KEY_PATH}"';
-            }
-
-            if (null !== $backup->getBackupConfiguration()->getHost()->getPassword()) {
-                $sshpass = 'echo "${SSHPASS}" | ';
-            }
-
-            $sshOptions = $this->buildSshOptionsString($backup->getBackupConfiguration()->getHost());
-
-            $command = \sprintf(
-                '%s sshfs "${LOGIN}@${IP}:${REMOTE_PATH}" "${DESTINATION}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null%s %s -o "uid=%d,gid=%d" -o ro %s',
-                $sshpass ?? null,
-                $sshOptions,
-                $privateKeyString ?? null,
-                posix_getuid(),
-                posix_getgid(),
-                $backup->getBackupConfiguration()->getDumpCommand() // Unsafe use of shell command - allow to add options to sshfs
-            );
-            $parameters = [
-                'SSHPASS' => $backup->getBackupConfiguration()->getHost()->getPassword(),
-                'LOGIN' => $backup->getBackupConfiguration()->getHost()->getLogin(),
-                'IP' => $backup->getBackupConfiguration()->getHost()->getIp(),
-                'REMOTE_PATH' => $backup->getBackupConfiguration()->getRemotePath(),
-                'DESTINATION' => $backupDestination,
-                'PRIVATE_KEY_PATH' => $privateKeypath ?? null,
-            ];
-
-            $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-            $process = Process::fromShellCommandline($command, null, $parameters);
-            $process->setTimeout(self::SSHFS_MOUNT_TIMEOUT);
-            $process->run();
-
-            if (!$process->isSuccessful()) {
-                $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing download - exec dump command - %s', $process->getErrorOutput()));
-                throw new ProcessFailedException($process);
-            } else {
-                $this->log($backup, Log::LOG_INFO, $process->getOutput());
-            }
-
-            $this->log($backup, Log::LOG_NOTICE, 'Mount done');
-        } else {
-            $this->log($backup, Log::LOG_NOTICE, 'Already mounted');
-        }
-    }
-
-    private function downloadSftp(Backup $backup): void
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        $filesystem = new Filesystem();
-
-        if (null !== $backup->getBackupConfiguration()->getHost()->getPrivateKey()) {
-            $privateKeypath = $filesystem->tempnam('/tmp', 'key_');
-            $filesystem->appendToFile($privateKeypath, str_replace("\r", '', $backup->getBackupConfiguration()->getHost()->getPrivateKey()."\n"));
-            $privateKeyString = '-i ${PRIVATE_KEY_PATH}';
-        }
-
-        $command = \sprintf(
-            'sftp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null %s "${LOGIN}@${IP}:${REMOTE_DIRECTORY}" "${BACKUP_DESTINATION}"',
-            $privateKeyString ?? null
+        $backup = $this->backupRepository->findOneBy(
+            ['backupConfiguration' => $backupConfiguration],
+            ['id' => 'DESC'],
         );
-        $parameters = [
-            'PORT' => $backup->getBackupConfiguration()->getHost()->getPort() ?? 22,
-            'PRIVATE_KEY_PATH' => $privateKeypath ?? null,
-            'LOGIN' => $backup->getBackupConfiguration()->getHost()->getLogin(),
-            'IP' => $backup->getBackupConfiguration()->getHost()->getIp(),
-            'REMOTE_DIRECTORY' => $backup->getBackupConfiguration()->getRemotePath(),
-            'BACKUP_DESTINATION' => $this->getTemporaryBackupDestination($backup),
-        ];
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-        $process = Process::fromShellCommandline($command, null, $parameters);
-        $process->setTimeout(self::SSHFS_MOUNT_TIMEOUT);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing download - exec dump command - %s', $process->getErrorOutput()));
-            throw new ProcessFailedException($process);
-        } else {
-            $this->log($backup, Log::LOG_INFO, $process->getOutput());
-        }
-
-        $this->log($backup, Log::LOG_NOTICE, 'Download done');
-
-        $backup->setSize($this->getSftpDownloadSize($backup));
-    }
-
-    public function downloadBackup(Backup $backup): void
-    {
-        match ($backup->getBackupConfiguration()->getType()) {
-            BackupConfiguration::TYPE_OS_INSTANCE => $this->downloadOSSnapshot($backup),
-            BackupConfiguration::TYPE_MYSQL, BackupConfiguration::TYPE_POSTGRESQL, BackupConfiguration::TYPE_SQL_SERVER, BackupConfiguration::TYPE_SSH_CMD => $this->downloadCommandResult($backup),
-            BackupConfiguration::TYPE_KUBECONFIG => $this->downloadKubeCommandResult($backup),
-            BackupConfiguration::TYPE_SFTP => $this->downloadSftp($backup),
-            BackupConfiguration::TYPE_SSHFS => $this->downloadSSHFS($backup),
-            default => $this->log($backup, Log::LOG_INFO, \sprintf('%s : Nothing to do', $backup->getCurrentPlace())),
-        };
-    }
-
-    public function checkDownloadedFUSE(Backup $backup): bool
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        $command = 'grep -qs "${DIRECTORY}" /proc/mounts';
-        $parameters = [
-            'DIRECTORY' => $this->getTemporaryBackupDestination($backup),
-        ];
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-        $process = Process::fromShellCommandline($command, null, $parameters);
-        $process->setTimeout(self::OS_DOWNLOAD_TIMEOUT);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $this->log($backup, Log::LOG_ERROR, 'checkDownloadedFUSE : not mounted');
-
-            return false;
-        } else {
-            $this->log($backup, Log::LOG_NOTICE, 'checkDownloadedFUSE : mounted');
-
-            return true;
-        }
-    }
-
-    public function checkDownloadedDump(Backup $backup): bool
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        $dumpDestination = $this->getTemporaryBackupDestination($backup);
-
-        if ($backup->getSize() >= $backup->getBackupConfiguration()->getMinimumBackupSize()) {
-            $this->log($backup, Log::LOG_NOTICE, 'Backup downloaded');
-
-            return true;
-        } else {
-            $this->log($backup, Log::LOG_NOTICE, \sprintf('Backup not downloaded : %s < %s', StringUtils::humanizeFileSize(filesize($dumpDestination)), StringUtils::humanizeFileSize($backup->getBackupConfiguration()->getMinimumBackupSize())));
-
-            return false;
-        }
-    }
-
-    public function checkDownloadedOSSnapshot(Backup $backup): bool
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        $imageDestination = $this->getTemporaryBackupDestination($backup);
-
-        if (!$backup->getSize()) {
-            $this->log($backup, Log::LOG_NOTICE, 'Openstack image not backuped');
-
-            return false;
-        }
-
-        if (!file_exists($imageDestination) || filesize($imageDestination) !== $backup->getSize()) {
-            $this->log($backup, Log::LOG_NOTICE, \sprintf('Openstack image not downloaded : %s != %s', StringUtils::humanizeFileSize(filesize($imageDestination)), StringUtils::humanizeFileSize($backup->getSize())));
-
-            return false;
-        }
-
-        return true;
-    }
-
-    private function uploadBackupSSHResticRmScript(Backup $backup, string $privateKeypath, string $scriptFilePath): void
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        $sshOptions = $this->buildSshOptionsString($backup->getBackupConfiguration()->getHost());
-
-        $command = \sprintf(
-            'ssh %s@%s -p %d -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null%s -o IdentityFile=%s "sudo rm -f %s"',
-            $backup->getBackupConfiguration()->getHost()->getLogin(),
-            $backup->getBackupConfiguration()->getHost()->getIp(),
-            $backup->getBackupConfiguration()->getHost()->getPort() ?? 22,
-            $sshOptions,
-            $privateKeypath,
-            $scriptFilePath,
-        );
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s`', $command));
-        $process = Process::fromShellCommandline($command);
-        $process->setTimeout(self::RESTIC_UPLOAD_TIMEOUT);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - ssh restic remove script - %s', $process->getErrorOutput()));
-            throw new ProcessFailedException($process);
-        } else {
-            $this->log($backup, Log::LOG_INFO, $process->getOutput());
-        }
-    }
-
-    private function uploadBackupSSHRestic(Backup $backup): void
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        $env = $backup->getBackupConfiguration()->getStorage()->getEnv() + $backup->getBackupConfiguration()->getResticEnv();
-
-        $filesystem = new Filesystem();
-        $privateKeypath = $filesystem->tempnam('/tmp', 'key_');
-        $filesystem->appendToFile($privateKeypath, str_replace("\r", '', $backup->getBackupConfiguration()->getHost()->getPrivateKey()."\n"));
-
-        $scriptFilePath = $filesystem->tempnam('/tmp', 'env_');
-        $filesystem->appendToFile($scriptFilePath, \sprintf('#!/bin/bash%s', \PHP_EOL));
-        foreach ($env as $k => $v) {
-            $filesystem->appendToFile($scriptFilePath, \sprintf('export %s="%s"%s', $k, str_replace('"', '\\"', (string) $v), \PHP_EOL));
-        }
-        $filesystem->appendToFile($scriptFilePath, \sprintf(
-            'restic backup --tag host=%s --tag configuration=%s --host cloudbackup %s || exit 1%s',
-            $backup->getBackupConfiguration()->getHost()->getSlug(),
-            $backup->getBackupConfiguration()->getSlug(),
-            $backup->getBackupConfiguration()->getRemotePath(),
-            \PHP_EOL
-        ));
-
-        $command = \sprintf(
-            'scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentityFile=%s %s %s@%s:%s',
-            $privateKeypath,
-            $scriptFilePath,
-            $backup->getBackupConfiguration()->getHost()->getLogin(),
-            $backup->getBackupConfiguration()->getHost()->getIp(),
-            $scriptFilePath,
-        );
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s`', $command));
-        $process = Process::fromShellCommandline($command);
-        $process->setTimeout(self::RESTIC_UPLOAD_TIMEOUT);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - ssh restic scp - %s', $process->getErrorOutput()));
-            throw new ProcessFailedException($process);
-        }
-
-        $sshOptions = $this->buildSshOptionsString($backup->getBackupConfiguration()->getHost());
-
-        $command = \sprintf(
-            'ssh %s@%s -p %d -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null%s -o IdentityFile=%s "%s"',
-            $backup->getBackupConfiguration()->getHost()->getLogin(),
-            $backup->getBackupConfiguration()->getHost()->getIp(),
-            $backup->getBackupConfiguration()->getHost()->getPort() ?? 22,
-            $sshOptions,
-            $privateKeypath,
-            \sprintf(
-                'sudo chmod 700 %s && sudo chown root:root %s && sudo %s',
-                $scriptFilePath,
-                $scriptFilePath,
-                $scriptFilePath,
-            )
-        );
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s`', $command));
-
-        $process = Process::fromShellCommandline($command);
-        $process->setTimeout(self::RESTIC_UPLOAD_TIMEOUT);
-        $process->run();
-
-        $this->uploadBackupSSHResticRmScript($backup, $privateKeypath, $scriptFilePath);
-
-        if (!$process->isSuccessful()) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - ssh restic upload - %s', $process->getErrorOutput()));
-            throw new ProcessFailedException($process);
-        } else {
-            $this->log($backup, Log::LOG_INFO, $process->getOutput());
-        }
-    }
-
-    public function uploadBackup(Backup $backup): void
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        $env = $backup->getBackupConfiguration()->getStorage()->getEnv() + $backup->getBackupConfiguration()->getResticEnv();
-
-        switch ($backup->getBackupConfiguration()->getType()) {
-            case BackupConfiguration::TYPE_OS_INSTANCE:
-                $command = 'restic backup --tag project="${PROJECT}" --tag instance="${INSTANCE}" --tag configuration="${CONFIGURATION}" --host cloudbackup "${DIRECTORY}"';
-                $parameters = [
-                    'PROJECT' => $backup->getBackupConfiguration()->getOsInstance()->getOSProject()->getSlug(),
-                    'INSTANCE' => $backup->getBackupConfiguration()->getOsInstance()->getSlug(),
-                    'CONFIGURATION' => $backup->getBackupConfiguration()->getName(),
-                    'DIRECTORY' => $this->getTemporaryBackupDestination($backup),
-                ];
-
-                $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-                $process = Process::fromShellCommandline($command, null, $env + $parameters);
-                $process->setTimeout(self::RESTIC_UPLOAD_TIMEOUT);
-                $process->run();
-
-                if (!$process->isSuccessful()) {
-                    $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - restic upload - %s', $process->getErrorOutput()));
-                    throw new ProcessFailedException($process);
-                } else {
-                    $this->log($backup, Log::LOG_INFO, $process->getOutput());
-                }
-                break;
-            case BackupConfiguration::TYPE_MYSQL:
-            case BackupConfiguration::TYPE_POSTGRESQL:
-            case BackupConfiguration::TYPE_SQL_SERVER:
-            case BackupConfiguration::TYPE_SSH_CMD:
-                $command = 'restic backup --tag host="${HOST}" --tag configuration="${CONFIGURATION}" --host cloudbackup "${DIRECTORY}"';
-                $parameters = [
-                    'HOST' => null !== $backup->getBackupConfiguration()->getHost() ? $backup->getBackupConfiguration()->getHost()->getSlug() : 'direct',
-                    'CONFIGURATION' => $backup->getBackupConfiguration()->getName(),
-                    'DIRECTORY' => $this->getTemporaryBackupDestination($backup),
-                ];
-
-                $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-                $process = Process::fromShellCommandline($command, null, $env + $parameters);
-                $process->setTimeout(self::RESTIC_UPLOAD_TIMEOUT);
-                $process->run();
-
-                if (!$process->isSuccessful()) {
-                    $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - restic upload - %s', $process->getErrorOutput()));
-                    throw new ProcessFailedException($process);
-                } else {
-                    $this->log($backup, Log::LOG_INFO, $process->getOutput());
-                }
-                break;
-            case BackupConfiguration::TYPE_KUBECONFIG:
-                $command = 'restic backup --tag host="${HOST}" --tag configuration="${CONFIGURATION}" --host cloudbackup "${DIRECTORY}"';
-                $parameters = [
-                    'HOST' => null !== $backup->getBackupConfiguration()->getKubeconfig() ? $backup->getBackupConfiguration()->getKubeconfig()->getName() : 'direct',
-                    'CONFIGURATION' => $backup->getBackupConfiguration()->getName(),
-                    'DIRECTORY' => $this->getTemporaryBackupDestination($backup),
-                ];
-
-                $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-                $process = Process::fromShellCommandline($command, null, $env + $parameters);
-                $process->setTimeout(self::RESTIC_UPLOAD_TIMEOUT);
-                $process->run();
-
-                if (!$process->isSuccessful()) {
-                    $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - restic upload - %s', $process->getErrorOutput()));
-                    throw new ProcessFailedException($process);
-                } else {
-                    $this->log($backup, Log::LOG_INFO, $process->getOutput());
-                }
-                break;
-            case BackupConfiguration::TYPE_SSHFS:
-            case BackupConfiguration::TYPE_SFTP:
-                $command = 'restic backup --tag host="${HOST}" --tag configuration="${CONFIGURATION}" --host cloudbackup "${DIRECTORY}"';
-                $parameters = [
-                    'HOST' => $backup->getBackupConfiguration()->getHost()->getSlug(),
-                    'CONFIGURATION' => $backup->getBackupConfiguration()->getName(),
-                    'DIRECTORY' => $this->getTemporaryBackupDestination($backup),
-                ];
-
-                $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-                $process = Process::fromShellCommandline($command, null, $env + $parameters);
-                $process->setTimeout(self::RESTIC_UPLOAD_TIMEOUT);
-                $process->run();
-
-                if (!$process->isSuccessful()) {
-                    $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - restic upload - %s', $process->getErrorOutput()));
-                    throw new ProcessFailedException($process);
-                } else {
-                    $this->log($backup, Log::LOG_INFO, $process->getOutput());
-                }
-                break;
-            case BackupConfiguration::TYPE_RCLONE:
-                $filesystem = new Filesystem();
-                $configFile = $filesystem->tempnam('/tmp', 'key_');
-                $filesystem->appendToFile($configFile, $backup->getBackupConfiguration()->getCompleteRcloneConfiguration());
-
-                $daily_backup_dir = \sprintf('%s/%s', $backup->getBackupConfiguration()->getRcloneBackupDir(), date('Y-m-d'));
-                $command = 'rclone sync "${SOURCE_LOCATION}" "${REMOTE_STORAGE_LOCATION}" --backup-dir "${REMOTE_STORAGE_BACKUP}" --config "${RCLONE_CONFIG}" ${RCLONE_FLAGS}';
-                $parameters = [
-                    'SOURCE_LOCATION' => $backup->getBackupConfiguration()->getRemotePath(),
-                    'REMOTE_STORAGE_LOCATION' => $backup->getBackupConfiguration()->getStorageSubPath(),
-                    'REMOTE_STORAGE_BACKUP' => $daily_backup_dir,
-                    'RCLONE_CONFIG' => $configFile,
-                    'RCLONE_FLAGS' => $backup->getBackupConfiguration()->getRcloneFlags(),
-                ];
-
-                $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, nl2br($this->logParameters($parameters))));
-                $process = Process::fromShellCommandline($command, null, $parameters);
-                $process->setTimeout(self::RCLONE_UPLOAD_TIMEOUT);
-                $process->run();
-
-                if (!$process->isSuccessful()) {
-                    if ($backup->getBackupConfiguration()->getStdErrIgnore() && '' === preg_replace('/^\s+/m', '', (string) preg_replace($backup->getBackupConfiguration()->getStdErrIgnore(), '', $process->getErrorOutput()))) {
-                        $this->log($backup, Log::LOG_WARNING, \sprintf('Warning executing backup - rclone sync - %s', $process->getErrorOutput()));
-                        break;
-                    }
-
-                    $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - rclone sync - %s', $process->getErrorOutput()));
-                    throw new ProcessFailedException($process);
-                } else {
-                    $this->log($backup, Log::LOG_INFO, $process->getOutput());
-                }
-                break;
-            case BackupConfiguration::TYPE_SSH_RESTIC:
-                $this->uploadBackupSSHRestic($backup);
-                break;
-            default:
-                $this->log($backup, Log::LOG_INFO, \sprintf('%s : Nothing to do', $backup->getCurrentPlace()));
-                break;
-        }
-    }
-
-    public function cleanBackupRestic(Backup $backup): void
-    {
-        $env = $backup->getBackupConfiguration()->getStorage()->getEnv() + $backup->getBackupConfiguration()->getResticEnv();
-
-        $command = \sprintf(
-            'restic forget --prune %s',
-            $backup->getBackupConfiguration()->getResticForgetArgs()
-        );
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s`', $command));
-        $process = Process::fromShellCommandline($command, null, $env);
-        $process->setTimeout(self::RESTIC_UPLOAD_TIMEOUT);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing cleanup - restic forget - %s', $process->getErrorOutput()));
-            throw new ProcessFailedException($process);
-        } else {
-            $this->log($backup, Log::LOG_INFO, $process->getOutput());
-        }
-    }
-
-    public function cleanBackupRclone(Backup $backup): void
-    {
-        if (null === $backup->getBackupConfiguration()->getRcloneBackupDir() || '' === $backup->getBackupConfiguration()->getRcloneBackupDir()) {
-            return;
-        }
-
-        $filesystem = new Filesystem();
-        $configFile = $filesystem->tempnam('/tmp', 'key_');
-        $filesystem->appendToFile($configFile, $backup->getBackupConfiguration()->getStorage()->getRcloneConfiguration());
-
-        $backup_parent_directory = \dirname($backup->getBackupConfiguration()->getRcloneBackupDir());
-        $backup_direcory = str_replace($backup_parent_directory.'/', '', $backup->getBackupConfiguration()->getRcloneBackupDir());
-
-        $command = 'rclone lsd "${REMOTE_STORAGE_DIRECTORY}" --config "${RCLONE_CONFIG}"';
-        $parameters = [
-            'REMOTE_STORAGE_DIRECTORY' => $backup_parent_directory,
-            'RCLONE_CONFIG' => $configFile,
-        ];
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-
-        $process = Process::fromShellCommandline($command, null, $parameters);
-        $process->setTimeout(self::RESTIC_UPLOAD_TIMEOUT);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - rclone lsd  - %s', $process->getErrorOutput()));
-            throw new ProcessFailedException($process);
-        } else {
-            $this->log($backup, Log::LOG_INFO, $process->getOutput());
-            if (!preg_match('/\s'.$backup_direcory.'\n/', $process->getOutput())) {
-                $this->log($backup, Log::LOG_INFO, \sprintf('INFO executing backup %s does not seems to exists', $backup->getBackupConfiguration()->getRcloneBackupDir()));
-
-                return;
-            }
-        }
-
-        // Calculate retention period as max of keepDaily and keepWeekly
-        $keepDaily = $backup->getBackupConfiguration()->getKeepDaily();
-        $keepWeekly = $backup->getBackupConfiguration()->getKeepWeekly();
-
-        // Ensure both values are non-negative
-        if ($keepDaily < 0) {
-            $keepDaily = 0;
-        }
-        if ($keepWeekly < 0) {
-            $keepWeekly = 0;
-        }
-
-        $keepDays = max($keepDaily, $keepWeekly * 7);
-
-        // If both are 0, use a default of 7 days to prevent immediate deletion
-        if (0 === $keepDays) {
-            $keepDays = 7;
-            $this->log($backup, Log::LOG_WARNING, 'Both keepDaily and keepWeekly are 0. Using default retention of 7 days.');
-        }
-
-        $command = 'rclone delete --min-age "${KEEP_DAYS}d" "${REMOTE_STORAGE_BACKUP}" --config "${RCLONE_CONFIG}"';
-        $parameters = [
-            'KEEP_DAYS' => $keepDays,
-            'REMOTE_STORAGE_BACKUP' => $backup->getBackupConfiguration()->getRcloneBackupDir(),
-            'RCLONE_CONFIG' => $configFile,
-        ];
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-
-        $process = Process::fromShellCommandline($command, null, $parameters);
-        $process->setTimeout(self::RESTIC_UPLOAD_TIMEOUT);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - rclone delete  - %s', $process->getErrorOutput()));
-            throw new ProcessFailedException($process);
-        } else {
-            $this->log($backup, Log::LOG_INFO, $process->getOutput());
-        }
-
-        // Clean up old archive directories (YYYY-MM-DD folders)
-        $command = 'rclone lsf "${REMOTE_STORAGE_BACKUP}" --dirs-only --config "${RCLONE_CONFIG}"';
-        $parameters = [
-            'REMOTE_STORAGE_BACKUP' => $backup->getBackupConfiguration()->getRcloneBackupDir(),
-            'RCLONE_CONFIG' => $configFile,
-        ];
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-
-        $process = Process::fromShellCommandline($command, null, $parameters);
-        $process->setTimeout(self::RCLONE_CHECK_TIMEOUT);
-        $process->run();
-
-        if ($process->isSuccessful()) {
-            $this->log($backup, Log::LOG_INFO, $process->getOutput());
-            $directories = array_filter(explode("\n", trim($process->getOutput())), fn ($dir) => '' !== $dir);
-
-            $cutoffDate = new DateTime()->modify(\sprintf('-%d days', $keepDays));
-            // Set time to midnight for accurate day-level comparison
-            $cutoffDate->setTime(0, 0, 0);
-
-            foreach ($directories as $directory) {
-                $directory = rtrim($directory, '/');
-                // Check if directory matches YYYY-MM-DD format
-                if (preg_match('/^(\d{4}-\d{2}-\d{2})$/', $directory, $matches)) {
-                    try {
-                        // Use createFromFormat with strict validation to ensure valid dates
-                        // The '!' prefix resets time components to prevent date overflow
-                        $dirDate = DateTime::createFromFormat('!Y-m-d', $matches[1]);
-                        $errors = DateTime::getLastErrors();
-
-                        // Validate date is valid and matches expected format
-                        $hasErrors = $errors && ($errors['warning_count'] > 0 || $errors['error_count'] > 0);
-                        $isValidFormat = false !== $dirDate && $dirDate->format('Y-m-d') === $matches[1];
-
-                        if (!$isValidFormat || $hasErrors) {
-                            $this->log($backup, Log::LOG_WARNING, \sprintf('Invalid date in directory name: %s', $directory));
-                            continue;
-                        }
-
-                        if ($dirDate < $cutoffDate) {
-                            // Delete old archive directory
-                            $archiveDir = rtrim($backup->getBackupConfiguration()->getRcloneBackupDir(), '/').'/'.$directory;
-                            $command = 'rclone purge "${ARCHIVE_DIR}" --config "${RCLONE_CONFIG}"';
-                            $parameters = [
-                                'ARCHIVE_DIR' => $archiveDir,
-                                'RCLONE_CONFIG' => $configFile,
-                            ];
-
-                            $this->log($backup, Log::LOG_INFO, \sprintf('Attempting to delete old archive directory: %s (older than %d days retention period)', $directory, $keepDays));
-                            $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-
-                            $deleteProcess = Process::fromShellCommandline($command, null, $parameters);
-                            $deleteProcess->setTimeout(self::RCLONE_CHECK_TIMEOUT);
-                            $deleteProcess->run();
-
-                            if (!$deleteProcess->isSuccessful()) {
-                                $this->log($backup, Log::LOG_WARNING, \sprintf('Failed to delete archive directory %s: %s', $directory, $deleteProcess->getErrorOutput()));
-                            } else {
-                                $this->log($backup, Log::LOG_INFO, \sprintf('Successfully deleted archive directory: %s', $directory));
-                            }
-                        }
-                    } catch (Exception $e) {
-                        $this->log($backup, Log::LOG_WARNING, \sprintf('Error parsing date for directory %s: %s', $directory, $e->getMessage()));
-                    }
-                }
-            }
-        } else {
-            $this->log($backup, Log::LOG_WARNING, \sprintf('Failed to list archive directories: %s', $process->getErrorOutput()));
-        }
-
-        $command = 'rclone rmdirs "${REMOTE_STORAGE_BACKUP}" --config "${RCLONE_CONFIG}"';
-        $parameters = [
-            'REMOTE_STORAGE_BACKUP' => $backup->getBackupConfiguration()->getRcloneBackupDir(),
-            'RCLONE_CONFIG' => $configFile,
-        ];
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-
-        $process = Process::fromShellCommandline($command, null, $parameters);
-        $process->setTimeout(self::RESTIC_UPLOAD_TIMEOUT);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - rclone rmdirs  - %s', $process->getErrorOutput()));
-            throw new ProcessFailedException($process);
-        } else {
-            $this->log($backup, Log::LOG_INFO, $process->getOutput());
-        }
-    }
-
-    private function cleanBackupFUSE(Backup $backup): void
-    {
-        if ($this->checkDownloadedFUSE($backup)) {
-            $command = 'fusermount -u "${DIRECTORY}"';
-            $parameters = [
-                'DIRECTORY' => $this->getTemporaryBackupDestination($backup),
-            ];
-
-            $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-            $process = Process::fromShellCommandline($command, null, $parameters);
-            $process->setTimeout(self::SSHFS_UMOUNT_TIMEOUT);
-            $process->run();
-
-            if (!$process->isSuccessful()) {
-                $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing cleanup - exec umount command - %s', $process->getErrorOutput()));
-                throw new ProcessFailedException($process);
-            } else {
-                $this->log($backup, Log::LOG_INFO, $process->getOutput());
-            }
-        }
-
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('Remove local file - %s', $this->getTemporaryBackupDestination($backup)));
-        if (2 !== (is_countable(scandir($this->getTemporaryBackupDestination($backup))) ? \count(scandir($this->getTemporaryBackupDestination($backup))) : 0)) {
-            $message = \sprintf('Error executing cleanup - %s directory is not empty', $this->getTemporaryBackupDestination($backup));
-            $this->log($backup, Log::LOG_ERROR, $message);
-            throw new Exception($message);
-        } else {
-            // php's rmdir function only remove empty directories
-            rmdir($this->getTemporaryBackupDestination($backup));
-        }
-    }
-
-    private function cleanBackupSftp(Backup $backup): void
-    {
-        if ($this->checkDownloadedDump($backup)) {
-            $this->log($backup, Log::LOG_NOTICE, \sprintf('Remove local directory - %s', $this->getTemporaryBackupDestination($backup)));
-
-            $filesystem = new Filesystem();
-            $filesystem->remove($this->getTemporaryBackupDestination($backup));
-        }
-    }
-
-    private function cleanBackupOsInstance(Backup $backup): void
-    {
-        if (null !== $this->getSnapshotOsInstanceStatus($backup)) {
-            $command = 'openstack image delete ${OS_IMAGE_ID}';
-            $parameters = [
-                'OS_IMAGE_ID' => $backup->getOsImageId(),
-            ];
-
-            $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-            $process = Process::fromShellCommandline($command, null, $parameters + $backup->getBackupConfiguration()->getOsInstance()->getOSEnv());
-            $process->setTimeout(self::OS_IMAGE_LIST_TIMEOUT);
-            $process->run();
-
-            if (!$process->isSuccessful()) {
-                $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing cleanup - openstack image image - %s', $process->getErrorOutput()));
-                throw new ProcessFailedException($process);
-            } else {
-                $this->log($backup, Log::LOG_INFO, $process->getOutput());
-            }
-        }
-    }
-
-    private function cleanRemoteByCommand(Backup $backup): void
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        $filesystem = new Filesystem();
-
-        if (null !== $backup->getBackupConfiguration()->getHost()->getPrivateKey()) {
-            $privateKeypath = $filesystem->tempnam('/tmp', 'key_');
-            $filesystem->appendToFile($privateKeypath, str_replace("\r", '', $backup->getBackupConfiguration()->getHost()->getPrivateKey()."\n"));
-            $privateKeyString = '-i ${PRIVATE_KEY_PATH}';
-        }
-
-        if (null !== $backup->getBackupConfiguration()->getHost()->getPassword()) {
-            $sshpass = 'sshpass -p ${SSHPASS}';
-        }
-
-        $sshOptions = $this->buildSshOptionsString($backup->getBackupConfiguration()->getHost());
-
-        $command = \sprintf(
-            '%s ssh "${LOGIN}@${IP}" -p "${PORT}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null%s %s "${REMOTE_CLEAN_COMMAND}"',
-            $sshpass ?? null,
-            $sshOptions,
-            $privateKeyString ?? null
-        );
-        $parameters = [
-            'SSHPASS' => $backup->getBackupConfiguration()->getHost()->getPassword(),
-            'LOGIN' => $backup->getBackupConfiguration()->getHost()->getLogin(),
-            'IP' => $backup->getBackupConfiguration()->getHost()->getIp(),
-            'PORT' => $backup->getBackupConfiguration()->getHost()->getPort() ?? 22,
-            'PRIVATE_KEY_PATH' => $privateKeypath ?? null,
-            'REMOTE_CLEAN_COMMAND' => $backup->getBackupConfiguration()->getRemoteCleanCommand(),
-        ];
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-        $process = Process::fromShellCommandline($command, null, $parameters);
-        $process->setTimeout(self::OS_DOWNLOAD_TIMEOUT);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing download - exec remote cleanup command - %s', $process->getErrorOutput()));
-            throw new ProcessFailedException($process);
-        } else {
-            $this->log($backup, Log::LOG_INFO, $process->getOutput());
-        }
-
-        $this->log($backup, Log::LOG_NOTICE, 'Remote cleanup done');
-    }
-
-    public function cleanBackup(Backup $backup): void
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        // Remove local temporary file / directory
-        if (file_exists($this->getTemporaryBackupDestination($backup))) {
-            switch ($backup->getBackupConfiguration()->getType()) {
-                case BackupConfiguration::TYPE_MYSQL:
-                case BackupConfiguration::TYPE_POSTGRESQL:
-                case BackupConfiguration::TYPE_SQL_SERVER:
-                case BackupConfiguration::TYPE_OS_INSTANCE:
-                case BackupConfiguration::TYPE_SSH_CMD:
-                    $this->log($backup, Log::LOG_NOTICE, \sprintf('Remove local file - %s', $this->getTemporaryBackupDestination($backup)));
-                    unlink($this->getTemporaryBackupDestination($backup));
-                    break;
-                case BackupConfiguration::TYPE_SFTP:
-                    $this->cleanBackupSftp($backup);
-                    break;
-                case BackupConfiguration::TYPE_SSHFS:
-                    $this->cleanBackupFUSE($backup);
-                    break;
-            }
-        }
-
-        // Remove OS image
-        if (BackupConfiguration::TYPE_OS_INSTANCE === $backup->getBackupConfiguration()->getType()) {
-            $this->cleanBackupOsInstance($backup);
-        }
-
-        // Execute remote clean command
-        if (BackupConfiguration::TYPE_SSH_CMD === $backup->getBackupConfiguration()->getType() && (null !== $backup->getBackupConfiguration()->getRemoteCleanCommand() && '' !== $backup->getBackupConfiguration()->getRemoteCleanCommand())) {
-            $this->cleanRemoteByCommand($backup);
-        }
-    }
-
-    public function isBackupCleaned(Backup $backup): bool
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        switch ($backup->getBackupConfiguration()->getType()) {
-            case BackupConfiguration::TYPE_OS_INSTANCE:
-                if (null !== $this->getSnapshotOsInstanceStatus($backup)) {
-                    return false;
-                }
-
-                if (file_exists($this->getTemporaryBackupDestination($backup))) {
-                    $this->log($backup, Log::LOG_NOTICE, \sprintf('Backup location does exists - %s', $this->getTemporaryBackupDestination($backup)));
-
-                    return false;
-                }
-                break;
-            case BackupConfiguration::TYPE_MYSQL:
-            case BackupConfiguration::TYPE_POSTGRESQL:
-            case BackupConfiguration::TYPE_SQL_SERVER:
-            case BackupConfiguration::TYPE_SSH_CMD:
-            case BackupConfiguration::TYPE_SSHFS:
-            case BackupConfiguration::TYPE_SFTP:
-                if (file_exists($this->getTemporaryBackupDestination($backup))) {
-                    $this->log($backup, Log::LOG_NOTICE, \sprintf('Backup location does exists - %s', $this->getTemporaryBackupDestination($backup)));
-
-                    return false;
-                }
-                break;
-        }
-
-        return true;
-    }
-
-    public function healhCheckBackup(Backup $backup, bool $tryRepair = true): void
-    {
-        switch ($backup->getBackupConfiguration()->getStorage()->getType()) {
-            case Storage::TYPE_RESTIC:
-                $env = $backup->getBackupConfiguration()->getStorage()->getEnv() + $backup->getBackupConfiguration()->getResticEnv();
-
-                $command = 'restic check';
-
-                $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s`', $command));
-                $process = Process::fromShellCommandline($command, null, $env);
-                $process->setTimeout(self::RESTIC_CHECK_TIMEOUT);
-                $process->run();
-
-                if (!$process->isSuccessful()) {
-                    $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $process->getErrorOutput()));
-
-                    if ($tryRepair) {
-                        $this->repairBackup($backup, $process->getErrorOutput());
-                        $this->healhCheckBackup($backup, false);
-                    } else {
-                        throw new ProcessFailedException($process);
-                    }
-                } else {
-                    $this->log($backup, Log::LOG_INFO, $process->getOutput());
-                }
-
-                $command = \sprintf('restic snapshots --json --latest 1 -q %s',
-                    $backup->getBackupConfiguration()->getResticCheckTags() ? '--tag "${RESTIC_CHECK_TAG}"' : ''
-                );
-
-                $parameters = [
-                    'RESTIC_CHECK_TAG' => $backup->getBackupConfiguration()->getResticCheckTags(),
-                ];
-
-                $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, nl2br($this->logParameters($parameters))));
-
-                $process = Process::fromShellCommandline($command, null, $env + $parameters);
-                $process->setTimeout(self::RESTIC_CHECK_TIMEOUT);
-                $process->run();
-
-                if (!$process->isSuccessful()) {
-                    $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $process->getErrorOutput()));
-                    throw new ProcessFailedException($process);
-                } else {
-                    if (($json = json_decode($process->getOutput(), true, 512, \JSON_THROW_ON_ERROR)) === null || !(is_countable($json) ? \count($json) : 0)) {
-                        $message = \sprintf('Cannot decode json : %s', $process->getOutput());
-                        $this->log($backup, Log::LOG_ERROR, $message);
-                        throw new Exception($message);
-                    }
-
-                    usort($json, function ($a, $b) {
-                        // Sort latest in first
-                        return new DateTime($b['time']) <=> new DateTime($a['time']);
-                    });
-
-                    $prettyJson = json_encode($json, \JSON_PRETTY_PRINT);
-                    $this->log($backup, Log::LOG_INFO, $prettyJson);
-
-                    $lastBackup = new DateTime(preg_replace('/(\d+\-\d+\-\d+T\d+:\d+:\d+)\..*/', '$1', (string) $json[0]['time']));
-                    $this->log($backup, Log::LOG_NOTICE, \sprintf('Last backup : %s', $lastBackup->format('d/m/Y H:i')));
-
-                    $yesterday = new DateTime('yesterday');
-                    if ($lastBackup < $yesterday) {
-                        $message = 'Last backup older than 24h';
-                        $this->log($backup, Log::LOG_ERROR, $message);
-                        throw new Exception($message);
-                    }
-                }
-
-                $sizes = [
-                    '--mode restore-size latest' => 'resticSize',
-                    '--mode raw-data latest' => 'resticDedupSize',
-                    '--mode restore-size' => 'resticTotalSize',
-                    '--mode raw-data' => 'resticTotalDedupSize',
-                ];
-
-                foreach ($sizes as $resticCommandSuffix => $backupAttribute) {
-                    $command = \sprintf('restic stats --json %s %s', $resticCommandSuffix,
-                        $backup->getBackupConfiguration()->getResticCheckTags() ? '--tag "${RESTIC_CHECK_TAG}"' : ''
-                    );
-
-                    $parameters = [
-                        'RESTIC_CHECK_TAG' => $backup->getBackupConfiguration()->getResticCheckTags(),
-                    ];
-
-                    $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, nl2br($this->logParameters($parameters))));
-
-                    $process = Process::fromShellCommandline($command, null, $env + $parameters);
-                    $process->setTimeout(self::RESTIC_CHECK_TIMEOUT);
-                    $process->run();
-
-                    if (!$process->isSuccessful()) {
-                        $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $process->getErrorOutput()));
-                        throw new ProcessFailedException($process);
-                    } else {
-                        if (($json = json_decode($process->getOutput(), true, 512, \JSON_THROW_ON_ERROR)) === null) {
-                            $message = \sprintf('Cannot decode json : %s', $process->getOutput());
-                            $this->log($backup, Log::LOG_ERROR, $message);
-                            throw new Exception($message);
-                        }
-
-                        $prettyJson = json_encode($json, \JSON_PRETTY_PRINT);
-                        $this->log($backup, Log::LOG_INFO, $prettyJson);
-
-                        $accessor = PropertyAccess::createPropertyAccessor();
-                        $accessor->setValue($backup, $backupAttribute, $json['total_size']);
-
-                        $this->log($backup, Log::LOG_NOTICE, \sprintf('Stat %s : %s', $backupAttribute, StringUtils::humanizeFileSize($json['total_size'])));
-                    }
-                }
-
-                if (null === $backup->getSize()) {
-                    $backup->setSize($backup->getResticSize());
-                }
-
-                $minimumBackupSize = (int) $backup->getBackupConfiguration()->getMinimumBackupSize();
-                $resticSize = (int) $backup->getResticSize();
-
-                if ($resticSize <= $minimumBackupSize) {
-                    $message = \sprintf('Restic failed. Minimum backup size not met : %s < %s', StringUtils::humanizeFileSize($resticSize), StringUtils::humanizeFileSize($minimumBackupSize));
-                    $this->log($backup, Log::LOG_NOTICE, $message);
-                    throw new Exception($message);
-                }
-
-                if ($minimumBackupSize > 0 && $resticSize > self::BACKUP_SIZE_MAX_RATIO * $minimumBackupSize) {
-                    $newMinimumBackupSize = (int) ($minimumBackupSize * (1 + (self::BACKUP_SIZE_MAX_RATIO - 1) / 2));
-                    $message = \sprintf('Restic backup size %s exceeds %dx the expected size %s. Updating expected size to %s.', StringUtils::humanizeFileSize($resticSize), self::BACKUP_SIZE_MAX_RATIO, StringUtils::humanizeFileSize($minimumBackupSize), StringUtils::humanizeFileSize($newMinimumBackupSize));
-                    $this->log($backup, Log::LOG_NOTICE, $message);
-                    $backup->getBackupConfiguration()->setMinimumBackupSize((string) $newMinimumBackupSize);
-                }
-
-                break;
-            case Storage::TYPE_RCLONE:
-                $filesystem = new Filesystem();
-                $configFile = $filesystem->tempnam('/tmp', 'key_');
-                $filesystem->appendToFile($configFile, $backup->getBackupConfiguration()->getCompleteRcloneConfiguration());
-                $env = $backup->getBackupConfiguration()->getStorage()->getEnv() + $backup->getBackupConfiguration()->getResticEnv();
-
-                if ($backup->getBackupConfiguration()->isSkipRcloneCheck()) {
-                    $this->log($backup, Log::LOG_NOTICE, 'Skipping rclone check (skipRcloneCheck enabled on configuration)');
-                } else {
-                    $isCrypt = preg_match('/^\s*type\s*=\s*crypt\s*$/m', (string) $backup->getBackupConfiguration()->getCompleteRcloneConfiguration());
-
-                    $command = 'rclone "${CHECK}" "${SOURCE_LOCATION}" "${REMOTE_STORAGE_LOCATION}" --config "${RCLONE_CONFIG}"';
-                    $parameters = [
-                        'CHECK' => $isCrypt ? 'cryptcheck' : 'check',
-                        'SOURCE_LOCATION' => $backup->getBackupConfiguration()->getRemotePath(),
-                        'REMOTE_STORAGE_LOCATION' => $backup->getBackupConfiguration()->getStorageSubPath(),
-                        'RCLONE_CONFIG' => $configFile,
-                    ];
-
-                    $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, nl2br($this->logParameters($parameters))));
-                    $process = Process::fromShellCommandline($command, null, $parameters);
-
-                    $process->setTimeout(self::RCLONE_CHECK_TIMEOUT);
-                    $process->run();
-
-                    if (!$process->isSuccessful()) {
-                        $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $process->getErrorOutput()));
-                        throw new ProcessFailedException($process);
-                    } else {
-                        $this->log($backup, Log::LOG_INFO, $process->getOutput());
-                    }
-                }
-
-                $command = 'rclone size "${REMOTE_STORAGE_LOCATION}" --config "${RCLONE_CONFIG}" --json';
-                $parameters = [
-                    'REMOTE_STORAGE_LOCATION' => $backup->getBackupConfiguration()->getStorageSubPath(),
-                    'RCLONE_CONFIG' => $configFile,
-                ];
-
-                $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-                $process = Process::fromShellCommandline($command, null, $parameters);
-                $process->setTimeout(self::RCLONE_CHECK_TIMEOUT);
-                $process->run();
-
-                if (!$process->isSuccessful()) {
-                    $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing backup - rclone size - %s', $process->getErrorOutput()));
-                    throw new ProcessFailedException($process);
-                } else {
-                    $this->log($backup, Log::LOG_INFO, $process->getOutput());
-                }
-
-                $output = json_decode($process->getOutput(), true, 512, \JSON_THROW_ON_ERROR);
-                if (null === $output) {
-                    $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing rclone size - %s - %s', $process->getOutput(), $process->getErrorOutput()));
-                    throw new ProcessFailedException($process);
-                }
-
-                $backup->setSize($output['bytes']);
-
-                $minimumBackupSize = (int) $backup->getBackupConfiguration()->getMinimumBackupSize();
-
-                if ($output['bytes'] <= $minimumBackupSize) {
-                    $message = \sprintf('Rclone failed. Minimum backup size not met : %s < %s', StringUtils::humanizeFileSize($output['bytes']), StringUtils::humanizeFileSize($minimumBackupSize));
-                    $this->log($backup, Log::LOG_NOTICE, $message);
-                    throw new Exception($message);
-                }
-
-                if ($minimumBackupSize > 0 && $output['bytes'] > self::BACKUP_SIZE_MAX_RATIO * $minimumBackupSize) {
-                    $newMinimumBackupSize = (int) ($minimumBackupSize * (1 + (self::BACKUP_SIZE_MAX_RATIO - 1) / 2));
-                    $message = \sprintf('Rclone backup size %s exceeds %dx the expected size %s. Updating expected size to %s.', StringUtils::humanizeFileSize($output['bytes']), self::BACKUP_SIZE_MAX_RATIO, StringUtils::humanizeFileSize($minimumBackupSize), StringUtils::humanizeFileSize($newMinimumBackupSize));
-                    $this->log($backup, Log::LOG_NOTICE, $message);
-                    $backup->getBackupConfiguration()->setMinimumBackupSize((string) $newMinimumBackupSize);
-                }
-                break;
-            case Storage::TYPE_KOPIA:
-                $storage = $backup->getBackupConfiguration()->getStorage();
-                $env = $storage->getEnv() + $backup->getBackupConfiguration()->getKopiaEnv();
-
-                $filesystem = new Filesystem();
-                $configFile = $filesystem->tempnam('/tmp', 'kopia_');
-
-                try {
-                    // 1. Connect to the repository (per-call, ephemeral config file).
-                    // storageSubPath, when set, is passed as `--prefix` so several configurations
-                    // can share one Kopia repository on the same backend bucket.
-                    $parameters = ['KOPIA_CONFIG' => $configFile];
-                    $prefixClause = '';
-                    $storageSubPath = trim((string) $backup->getBackupConfiguration()->getStorageSubPath());
-                    if ('' !== $storageSubPath) {
-                        $prefixClause = ' --prefix="${KOPIA_PREFIX}"';
-                        $parameters['KOPIA_PREFIX'] = $storageSubPath;
-                    }
-                    $command = \sprintf(
-                        'kopia repository connect %s %s%s --config-file="${KOPIA_CONFIG}"',
-                        escapeshellarg((string) $storage->getKopiaBackend()),
-                        (string) $storage->getKopiaConnectArgs(),
-                        $prefixClause,
-                    );
-
-                    $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-                    $process = Process::fromShellCommandline($command, null, $env + $parameters);
-                    $process->setTimeout(self::KOPIA_CHECK_TIMEOUT);
-                    $process->run();
-
-                    if (!$process->isSuccessful()) {
-                        $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $process->getErrorOutput()));
-                        throw new ProcessFailedException($process);
-                    }
-
-                    // 2. Integrity verification (manifests + content metadata, no blob fetch).
-                    $command = 'kopia --config-file="${KOPIA_CONFIG}" snapshot verify --verify-files-percent=0';
-                    $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-                    $process = Process::fromShellCommandline($command, null, $env + $parameters);
-                    $process->setTimeout(self::KOPIA_CHECK_TIMEOUT);
-                    $process->run();
-
-                    if (!$process->isSuccessful()) {
-                        $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $process->getErrorOutput()));
-                        throw new ProcessFailedException($process);
-                    } else {
-                        $this->log($backup, Log::LOG_INFO, $process->getOutput());
-                    }
-
-                    // 3. Snapshot listing and freshness check.
-                    // Kopia's --tags flag is repeatable (one tag per flag, not CSV), so split the
-                    // whitespace-separated config value into one --tags invocation per token.
-                    $tagsClause = '';
-                    $listParameters = $parameters;
-                    $rawTags = trim((string) $backup->getBackupConfiguration()->getKopiaCheckTags());
-                    if ('' !== $rawTags) {
-                        foreach (preg_split('/\s+/', $rawTags) as $idx => $token) {
-                            $key = \sprintf('KOPIA_CHECK_TAG_%d', $idx);
-                            $tagsClause .= \sprintf(' --tags "${%s}"', $key);
-                            $listParameters[$key] = $token;
-                        }
-                    }
-                    $command = 'kopia --config-file="${KOPIA_CONFIG}" snapshot list --json'.$tagsClause;
-
-                    $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($listParameters)));
-                    $process = Process::fromShellCommandline($command, null, $env + $listParameters);
-                    $process->setTimeout(self::KOPIA_CHECK_TIMEOUT);
-                    $process->run();
-
-                    if (!$process->isSuccessful()) {
-                        $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $process->getErrorOutput()));
-                        throw new ProcessFailedException($process);
-                    }
-
-                    $snapshots = json_decode($process->getOutput(), true, 512, \JSON_THROW_ON_ERROR);
-                    if (!\is_array($snapshots) || [] === $snapshots) {
-                        $message = \sprintf('Cannot decode json or empty snapshot list : %s', $process->getOutput());
-                        $this->log($backup, Log::LOG_ERROR, $message);
-                        throw new Exception($message);
-                    }
-
-                    usort($snapshots, static function ($a, $b) {
-                        return new DateTime($b['endTime']) <=> new DateTime($a['endTime']);
-                    });
-
-                    $this->log($backup, Log::LOG_INFO, json_encode($snapshots, \JSON_PRETTY_PRINT));
-
-                    $lastBackup = new DateTime(preg_replace('/(\d+\-\d+\-\d+T\d+:\d+:\d+)\..*/', '$1', (string) $snapshots[0]['endTime']));
-                    $this->log($backup, Log::LOG_NOTICE, \sprintf('Last backup : %s', $lastBackup->format('d/m/Y H:i')));
-
-                    if ($lastBackup < new DateTime('yesterday')) {
-                        $message = 'Last backup older than 24h';
-                        $this->log($backup, Log::LOG_ERROR, $message);
-                        throw new Exception($message);
-                    }
-
-                    $backup->setKopiaSize((int) ($snapshots[0]['stats']['totalSize'] ?? 0));
-                    $backup->setKopiaTotalSize(array_sum(array_map(
-                        static fn (array $snapshot): int => (int) ($snapshot['stats']['totalSize'] ?? 0),
-                        $snapshots,
-                    )));
-                    $this->log($backup, Log::LOG_NOTICE, \sprintf('Stat kopiaSize : %s', StringUtils::humanizeFileSize($backup->getKopiaSize())));
-                    $this->log($backup, Log::LOG_NOTICE, \sprintf('Stat kopiaTotalSize : %s', StringUtils::humanizeFileSize($backup->getKopiaTotalSize())));
-
-                    // 4. Repository on-disk bytes — `blob stats --raw` walks backend blob listing.
-                    $command = 'kopia --config-file="${KOPIA_CONFIG}" blob stats --raw';
-                    $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s` with %s', $command, $this->logParameters($parameters)));
-                    $process = Process::fromShellCommandline($command, null, $env + $parameters);
-                    $process->setTimeout(self::KOPIA_CHECK_TIMEOUT);
-                    $process->run();
-
-                    if (!$process->isSuccessful()) {
-                        $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $process->getErrorOutput()));
-                        throw new ProcessFailedException($process);
-                    }
-
-                    // Output is plain text; parse the "Total: <bytes>" line emitted by Kopia.
-                    if (1 !== preg_match('/^Total:\s+(\d+)\s*$/m', $process->getOutput(), $matches)) {
-                        $message = \sprintf('Cannot read total dedup size from blob stats output : %s', $process->getOutput());
-                        $this->log($backup, Log::LOG_ERROR, $message);
-                        throw new Exception($message);
-                    }
-
-                    $backup->setKopiaTotalDedupSize((int) $matches[1]);
-                    $this->log($backup, Log::LOG_NOTICE, \sprintf('Stat kopiaTotalDedupSize : %s', StringUtils::humanizeFileSize($backup->getKopiaTotalDedupSize())));
-
-                    // 5. Default Backup::size to kopiaSize when not already set.
-                    if (null === $backup->getSize()) {
-                        $backup->setSize($backup->getKopiaSize());
-                    }
-
-                    // 6. Min / max-ratio size guards (mirror Restic and Rclone).
-                    $minimumBackupSize = (int) $backup->getBackupConfiguration()->getMinimumBackupSize();
-                    $kopiaSize = (int) $backup->getKopiaSize();
-
-                    if ($kopiaSize <= $minimumBackupSize) {
-                        $message = \sprintf('Kopia failed. Minimum backup size not met : %s < %s', StringUtils::humanizeFileSize($kopiaSize), StringUtils::humanizeFileSize($minimumBackupSize));
-                        $this->log($backup, Log::LOG_NOTICE, $message);
-                        throw new Exception($message);
-                    }
-
-                    if ($minimumBackupSize > 0 && $kopiaSize > self::BACKUP_SIZE_MAX_RATIO * $minimumBackupSize) {
-                        $newMinimumBackupSize = (int) ($minimumBackupSize * (1 + (self::BACKUP_SIZE_MAX_RATIO - 1) / 2));
-                        $message = \sprintf('Kopia backup size %s exceeds %dx the expected size %s. Updating expected size to %s.', StringUtils::humanizeFileSize($kopiaSize), self::BACKUP_SIZE_MAX_RATIO, StringUtils::humanizeFileSize($minimumBackupSize), StringUtils::humanizeFileSize($newMinimumBackupSize));
-                        $this->log($backup, Log::LOG_NOTICE, $message);
-                        $backup->getBackupConfiguration()->setMinimumBackupSize((string) $newMinimumBackupSize);
-                    }
-                } finally {
-                    @unlink($configFile);
-                }
-                break;
-        }
-    }
-
-    public function repairBackup(Backup $backup, ?string $errorOutput = null): void
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        $env = $backup->getBackupConfiguration()->getStorage()->getEnv() + $backup->getBackupConfiguration()->getResticEnv();
-
-        $commands = [
-            'restic repair index',
-            'restic prune',
-            'restic check',
-        ];
-
-        // If the repository is locked for more than RESTIC_LOCK_MAX_AGE_SECONDS, try to unlock it
-        if (null !== $errorOutput && preg_match('/repository is already locked/m', $errorOutput) && preg_match('/lock was created at .* \((\d+)h(\d+)m(\d+)\.(\d+)s ago/m', $errorOutput, $matches)) {
-            $hours = (int) $matches[1];
-            $minutes = (int) $matches[2];
-            $seconds = (int) $matches[3];
-            $totalSeconds = ($hours * 3600) + ($minutes * 60) + $seconds;
-
-            $message = \sprintf('Repository is locked since %dh%dm%ds', $hours, $minutes, $seconds);
-            $this->log($backup, Log::LOG_ERROR, $message);
-
-            if ($totalSeconds > self::RESTIC_LOCK_MAX_AGE_SECONDS) {
-                $message = \sprintf('Repository is locked since %dh%dm%ds which is more than the max allowed lock age of %ds', $hours, $minutes, $seconds, self::RESTIC_LOCK_MAX_AGE_SECONDS);
-                $this->log($backup, Log::LOG_ERROR, $message);
-
-                array_unshift($commands, 'restic unlock');
-            }
-        }
-
-        foreach ($commands as $command) {
-            $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s`', $command));
-            $process = Process::fromShellCommandline($command, null, $env);
-            $process->setTimeout(self::RESTIC_REPAIR_TIMEOUT);
-            $process->run();
-
-            if (!$process->isSuccessful()) {
-                $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $process->getErrorOutput()));
-                throw new ProcessFailedException($process);
-            } else {
-                $this->log($backup, Log::LOG_INFO, $process->getOutput());
-            }
-        }
-    }
-
-    public function resticInitRepo(Backup $backup): void
-    {
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-        $env = $backup->getBackupConfiguration()->getStorage()->getEnv() + $backup->getBackupConfiguration()->getResticEnv();
-
-        $command = '(restic snapshots > /dev/null 2>&1) || restic init';
-
-        $this->log($backup, Log::LOG_INFO, \sprintf('Run `%s`', $command));
-        $process = Process::fromShellCommandline($command, null, $env);
-        $process->setTimeout(self::RESTIC_INIT_TIMEOUT);
-        $process->run();
-
-        if (!$process->isSuccessful() && !preg_match(self::RESTIC_INIT_REGEX, $process->getErrorOutput())) {
-            $this->log($backup, Log::LOG_ERROR, \sprintf('Error executing %s::%s - %s - %s', self::class, __FUNCTION__, $command, $process->getErrorOutput()));
-            throw new ProcessFailedException($process);
-        } else {
-            $this->log($backup, Log::LOG_INFO, $process->getOutput());
-        }
-    }
-
-    public function getTemporaryBackupDestination(Backup $backup): string
-    {
-        switch ($backup->getBackupConfiguration()->getType()) {
-            case BackupConfiguration::TYPE_SSHFS:
-                return \sprintf('%s/%s', $this->temporaryDownloadDirectory, $backup->getName(false));
-            default:
-                if (null !== $backup->getBackupConfiguration()->getExtension()) {
-                    return \sprintf('%s/%s.%s', $this->temporaryDownloadDirectory, $backup->getName(false), $backup->getBackupConfiguration()->getExtension());
-                }
-
-                return \sprintf('%s/%s', $this->temporaryDownloadDirectory, $backup->getName(false));
-        }
-    }
-
-    public function initBackup(BackupConfiguration $backupConfiguration): void
-    {
-        $dateTime = new DateTime();
-
-        $backup = $this->backupRepository->findOneBy([
-            'backupConfiguration' => $backupConfiguration,
-        ], ['id' => 'DESC']);
 
         if (null === $backup) {
             $backup = new Backup();
             $backup->setBackupConfiguration($backupConfiguration);
         }
 
-        $backupWorkflow = $this->workflowRegistry->get($backup);
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s. CurrentState : %s', self::class, __FUNCTION__, $backup->getCurrentPlace()));
-        if ('backuped' === $backup->getCurrentPlace()) {
-            if ($backup->getCreatedAt()->format('Y-m-d') === $dateTime->format('Y-m-d') && BackupConfiguration::PERIODICITY_DAILY === $backupConfiguration->getPeriodicity()) {
-                return;
-            } else {
-                $backup = new Backup();
-                $backup->setBackupConfiguration($backupConfiguration);
-            }
-        } elseif ('initialized' !== $backup->getCurrentPlace()) {
-            $this->log($backup, Log::LOG_NOTICE, \sprintf('Resume backup with current state %s', $backup->getCurrentPlace()));
-            if ($backup->getCreatedAt()->format('Y-m-d') !== $dateTime->format('Y-m-d') && BackupConfiguration::PERIODICITY_DAILY === $backupConfiguration->getPeriodicity()) {
-                $this->log($backup, Log::LOG_NOTICE, 'Backup is not from today, force fail it');
-                if ('failed' !== $backup->getCurrentPlace()) {
-                    $backupWorkflow->apply($backup, 'failed');
-
-                    $this->entityManager->persist($backup);
-                    $this->entityManager->flush();
-                }
-
-                $backup = new Backup();
-                $backup->setBackupConfiguration($backupConfiguration);
-            } else {
-                $this->log($backup, Log::LOG_INFO, \sprintf('Resume backup with current state %s', $backup->getCurrentPlace()));
-            }
-        }
-
-        try {
-            $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s', self::class, __FUNCTION__));
-
-            if ($backupWorkflow->can($backup, 'start')) {
-                $backupWorkflow->apply($backup, 'start');
-            }
-
-            // Some backup types can go through start to upload without dump and download
-            if ($backupWorkflow->can($backup, 'upload')) {
-                $backupWorkflow->apply($backup, 'upload');
-            } elseif ($backupWorkflow->can($backup, 'dump')) {
-                $backupWorkflow->apply($backup, 'dump');
-            }
-        } catch (Exception $e) {
-            $this->log($backup, Log::LOG_NOTICE, \sprintf('An error occured : %s', $e->getMessage()));
-
-            if ($backupWorkflow->can($backup, 'failed')) {
-                $backupWorkflow->apply($backup, 'failed');
-            }
-        }
-
-        $this->entityManager->persist($backup);
-        $this->entityManager->flush();
+        return $backup;
     }
 
-    public function performBackup(BackupConfiguration $backupConfiguration): void
+    private function findLatestBackupOrFail(BackupConfiguration $backupConfiguration): Backup
     {
-        $backup = $this->backupRepository->findOneBy([
-            'backupConfiguration' => $backupConfiguration,
-        ], ['id' => 'DESC']);
+        $backup = $this->backupRepository->findOneBy(
+            ['backupConfiguration' => $backupConfiguration],
+            ['id' => 'DESC'],
+        );
 
         if (null === $backup) {
             throw new Exception(\sprintf('No backup found: %s', $backupConfiguration->getName()));
         }
 
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s. CurrentState : %s', self::class, __FUNCTION__, $backup->getCurrentPlace()));
-
-        try {
-            $backupWorkflow = $this->workflowRegistry->get($backup);
-
-            if ($backupWorkflow->can($backup, 'download')) {
-                $backupWorkflow->apply($backup, 'download');
-            }
-
-            if ($backupWorkflow->can($backup, 'upload')) {
-                $backupWorkflow->apply($backup, 'upload');
-            }
-
-            if ($backupWorkflow->can($backup, 'cleanup')) {
-                $backupWorkflow->apply($backup, 'cleanup');
-            }
-        } catch (Exception $e) {
-            $this->log($backup, Log::LOG_NOTICE, \sprintf('An error occured : %s', $e->getMessage()));
-
-            if ($backupWorkflow->can($backup, 'failed')) {
-                $backupWorkflow->apply($backup, 'failed');
-            }
-        }
-
-        $this->entityManager->persist($backup);
-        $this->entityManager->flush();
+        return $backup;
     }
 
-    public function completeBackup(BackupConfiguration $backupConfiguration): void
+    private function failWorkflow(Backup $backup, WorkflowInterface $workflow, Exception $exception): void
     {
-        $backup = $this->backupRepository->findOneBy([
-            'backupConfiguration' => $backupConfiguration,
-        ], ['id' => 'DESC']);
+        $this->backupLogger->log($backup, Log::LOG_NOTICE, \sprintf('An error occured : %s', $exception->getMessage()));
 
-        if (null === $backup) {
-            throw new Exception(\sprintf('No backup found: %s', $backupConfiguration->getName()));
+        if ($workflow->can($backup, 'failed')) {
+            $workflow->apply($backup, 'failed');
         }
-
-        $this->log($backup, Log::LOG_NOTICE, \sprintf('call %s::%s. CurrentState : %s', self::class, __FUNCTION__, $backup->getCurrentPlace()));
-
-        $backupWorkflow = $this->workflowRegistry->get($backup);
-
-        try {
-            if ($backupWorkflow->can($backup, 'health_check')) {
-                $backupWorkflow->apply($backup, 'health_check');
-            }
-
-            if ($backupWorkflow->can($backup, 'forget')) {
-                $backupWorkflow->apply($backup, 'forget');
-            }
-
-            if ($backupWorkflow->can($backup, 'backuped')) {
-                $backupWorkflow->apply($backup, 'backuped');
-            }
-        } catch (Exception $e) {
-            $this->log($backup, Log::LOG_NOTICE, \sprintf('An error occured : %s', $e->getMessage()));
-
-            if ($backupWorkflow->can($backup, 'failed')) {
-                $backupWorkflow->apply($backup, 'failed');
-            }
-        }
-
-        $this->entityManager->persist($backup);
-        $this->entityManager->flush();
-    }
-
-    /**
-     * Build SSH options string from host configuration
-     * Validates SSH options to prevent command injection.
-     */
-    private function buildSshOptionsString(?Host $host): string
-    {
-        if (!$host?->getSshOptions()) {
-            return '';
-        }
-
-        $sshOptions = trim($host->getSshOptions());
-
-        if (!preg_match(Host::SSH_OPTIONS_PATTERN, $sshOptions)) {
-            throw new InvalidArgumentException('SSH options contain invalid characters. Only alphanumeric characters, spaces, and the following special characters are allowed: - = , + . / : _');
-        }
-
-        return ' '.$sshOptions;
     }
 }

--- a/tests/Backup/Logging/BackupLoggerTest.php
+++ b/tests/Backup/Logging/BackupLoggerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Backup\Logging;
+
+use App\Backup\Logging\BackupLogger;
+use App\Entity\Backup;
+use App\Entity\Log;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class BackupLoggerTest extends TestCase
+{
+    public function testLogPersistsLogEntityAndFlushes(): void
+    {
+        $backup = new Backup();
+        $psr = $this->createMock(LoggerInterface::class);
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        $psr->expects($this->once())->method('info')->with('hello');
+
+        $em->expects($this->exactly(2))->method('persist')
+            ->willReturnCallback(static function (object $entity) use ($backup): void {
+                if ($entity instanceof Log) {
+                    self::assertSame(Log::LOG_INFO, $entity->getLevel());
+                    self::assertSame('hello', $entity->getMessage());
+
+                    return;
+                }
+                self::assertSame($backup, $entity);
+            });
+
+        $em->expects($this->once())->method('flush');
+
+        new BackupLogger($psr, $em)->log($backup, Log::LOG_INFO, 'hello');
+
+        self::assertCount(1, $backup->getLogs());
+    }
+
+    public function testLogRoutesErrorLevelToPsrError(): void
+    {
+        $backup = new Backup();
+        $psr = $this->createMock(LoggerInterface::class);
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        $psr->expects($this->once())->method('error')->with('boom');
+
+        new BackupLogger($psr, $em)->log($backup, Log::LOG_ERROR, 'boom');
+    }
+
+    public function testLogRejectsUnknownLevel(): void
+    {
+        $logger = new BackupLogger(
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(EntityManagerInterface::class),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $logger->log(new Backup(), 'debug', 'never');
+    }
+
+    public function testFormatParametersReturnsJsonWithoutTags(): void
+    {
+        $logger = new BackupLogger(
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(EntityManagerInterface::class),
+        );
+
+        $out = $logger->formatParameters(['a' => '<b>x</b>']);
+
+        self::assertStringNotContainsString('<b>', $out);
+        self::assertStringContainsString('"a":', $out);
+    }
+}

--- a/tests/Backup/Path/TemporaryPathResolverTest.php
+++ b/tests/Backup/Path/TemporaryPathResolverTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Backup\Path;
+
+use App\Backup\Path\TemporaryPathResolver;
+use App\Entity\Backup;
+use App\Entity\BackupConfiguration;
+use PHPUnit\Framework\TestCase;
+
+final class TemporaryPathResolverTest extends TestCase
+{
+    public function testSshfsTypeOmitsExtensionEvenWhenSet(): void
+    {
+        $resolver = new TemporaryPathResolver('/tmp/bkp');
+
+        $configuration = new BackupConfiguration()
+            ->setName('shareA')
+            ->setSlug('share-a')
+            ->setType(BackupConfiguration::TYPE_SSHFS)
+            ->setCustomExtension('tar.gz');
+        $backup = new Backup()->setBackupConfiguration($configuration);
+
+        self::assertSame('/tmp/bkp/share-a', $resolver->resolve($backup));
+    }
+
+    public function testDefaultPathAppendsExtensionWhenSet(): void
+    {
+        $resolver = new TemporaryPathResolver('/tmp/bkp');
+
+        $configuration = new BackupConfiguration()
+            ->setName('db')
+            ->setSlug('db')
+            ->setType(BackupConfiguration::TYPE_MYSQL)
+            ->setCustomExtension('sql.gz');
+        $backup = new Backup()->setBackupConfiguration($configuration);
+
+        self::assertSame('/tmp/bkp/db.sql.gz', $resolver->resolve($backup));
+    }
+
+    public function testDefaultPathWithoutCustomExtensionFallsBackToTypeDefault(): void
+    {
+        $resolver = new TemporaryPathResolver('/var/cache/bkp');
+
+        $configuration = new BackupConfiguration()
+            ->setName('vm')
+            ->setSlug('vm')
+            ->setType(BackupConfiguration::TYPE_OS_INSTANCE);
+        $backup = new Backup()->setBackupConfiguration($configuration);
+
+        self::assertSame('/var/cache/bkp/vm.qcow2', $resolver->resolve($backup));
+    }
+
+    public function testDefaultPathFallsBackToBareSlugForTypesWithoutDefaultExtension(): void
+    {
+        $resolver = new TemporaryPathResolver('/var/cache/bkp');
+
+        $configuration = new BackupConfiguration()
+            ->setName('shr')
+            ->setSlug('shr')
+            ->setType(BackupConfiguration::TYPE_RCLONE);
+        $backup = new Backup()->setBackupConfiguration($configuration);
+
+        self::assertSame('/var/cache/bkp/shr', $resolver->resolve($backup));
+    }
+}

--- a/tests/Backup/Process/ProcessRunnerTest.php
+++ b/tests/Backup/Process/ProcessRunnerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Backup\Process;
+
+use App\Backup\Process\ProcessRunner;
+use PHPUnit\Framework\TestCase;
+
+final class ProcessRunnerTest extends TestCase
+{
+    public function testSuccessfulCommandReturnsSuccessOutcome(): void
+    {
+        $outcome = new ProcessRunner()->runShell('echo "${MSG}"', ['MSG' => 'hi'], 5);
+
+        self::assertTrue($outcome->successful);
+        self::assertSame(0, $outcome->exitCode);
+        self::assertStringContainsString('hi', $outcome->output);
+    }
+
+    public function testFailingCommandReturnsFailureOutcome(): void
+    {
+        $outcome = new ProcessRunner()->runShell('exit 7', [], 5);
+
+        self::assertFalse($outcome->successful);
+        self::assertSame(7, $outcome->exitCode);
+    }
+}

--- a/tests/Backup/Source/DumpSourceTest.php
+++ b/tests/Backup/Source/DumpSourceTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Backup\Source;
+
+use App\Backup\Logging\BackupLogger;
+use App\Backup\Path\TemporaryPathResolver;
+use App\Backup\Process\ProcessExecutionException;
+use App\Backup\Process\ProcessOutcome;
+use App\Backup\Process\ProcessRunnerInterface;
+use App\Backup\Source\DumpSource;
+use App\Backup\Ssh\SshKeyMaterializer;
+use App\Backup\Ssh\SshOptionsBuilder;
+use App\Backup\Storage\ResticStorageBackend;
+use App\Backup\Storage\StorageBackendRegistry;
+use App\Entity\Backup;
+use App\Entity\BackupConfiguration;
+use App\Entity\Storage;
+use PHPUnit\Framework\TestCase;
+
+final class DumpSourceTest extends TestCase
+{
+    public function testSupportsAllDumpTypes(): void
+    {
+        $source = $this->buildSource(
+            $this->createMock(ProcessRunnerInterface::class),
+            $this->createMock(BackupLogger::class),
+            $this->createMock(StorageBackendRegistry::class),
+        );
+
+        foreach (DumpSource::SUPPORTED_TYPES as $type) {
+            $configuration = new BackupConfiguration()->setType($type);
+            self::assertTrue($source->supports($configuration), $type);
+        }
+
+        self::assertFalse($source->supports(new BackupConfiguration()->setType(BackupConfiguration::TYPE_RCLONE)));
+    }
+
+    public function testDownloadWithoutHostUsesLocalShell(): void
+    {
+        $runner = $this->createMock(ProcessRunnerInterface::class);
+        $runner->expects($this->once())
+            ->method('runShell')
+            ->willReturnCallback(function (string $command, array $env): ProcessOutcome {
+                self::assertStringStartsWith('sh -c "${DUMP_COMMAND}"', $command);
+                self::assertSame('mysqldump db', $env['DUMP_COMMAND']);
+
+                return new ProcessOutcome(true, '', '', 0, $command);
+            });
+
+        $tempDir = sys_get_temp_dir();
+        $pathResolver = new TemporaryPathResolver($tempDir);
+
+        $source = new DumpSource(
+            $runner,
+            $this->createMock(BackupLogger::class),
+            $pathResolver,
+            $this->createMock(StorageBackendRegistry::class),
+            new SshOptionsBuilder(),
+            new SshKeyMaterializer(),
+        );
+
+        $configuration = new BackupConfiguration()
+            ->setName('db')
+            ->setSlug('db')
+            ->setType(BackupConfiguration::TYPE_MYSQL)
+            ->setDumpCommand('mysqldump db')
+            ->setCustomExtension('sql');
+        $backup = new Backup()
+            ->setBackupConfiguration($configuration)
+            ->setCreatedAt(new \DateTime('2026-05-16'));
+
+        $destination = $pathResolver->resolve($backup);
+        @unlink($destination);
+        file_put_contents($destination, 'fake-dump-bytes');
+
+        try {
+            $source->download($backup);
+            self::assertSame(\strlen('fake-dump-bytes'), $backup->getSize());
+        } finally {
+            @unlink($destination);
+        }
+    }
+
+    public function testDownloadThrowsWhenProcessFails(): void
+    {
+        $runner = $this->createMock(ProcessRunnerInterface::class);
+        $runner->method('runShell')->willReturn(new ProcessOutcome(false, '', 'no perms', 1, 'sh -c'));
+
+        $source = $this->buildSource($runner, $this->createMock(BackupLogger::class), $this->createMock(StorageBackendRegistry::class));
+
+        $configuration = new BackupConfiguration()
+            ->setName('db')
+            ->setSlug('db')
+            ->setType(BackupConfiguration::TYPE_MYSQL)
+            ->setDumpCommand('mysqldump db');
+        $backup = new Backup()
+            ->setBackupConfiguration($configuration)
+            ->setCreatedAt(new \DateTime('2026-05-16'));
+
+        $this->expectException(ProcessExecutionException::class);
+        $source->download($backup);
+    }
+
+    public function testUploadDelegatesToResticBackendWithTags(): void
+    {
+        $resticBackend = $this->createMock(ResticStorageBackend::class);
+        $resticBackend->method('supports')->willReturn(true);
+        $resticBackend->expects($this->once())
+            ->method('uploadLocal')
+            ->with(
+                $this->isInstanceOf(Backup::class),
+                $this->isType('string'),
+                self::callback(static fn (array $tags): bool => 'direct' === $tags['host'] && 'cfg' === $tags['configuration']),
+            );
+
+        $registry = $this->createMock(StorageBackendRegistry::class);
+        $registry->method('forStorage')->willReturn($resticBackend);
+
+        $source = $this->buildSource(
+            $this->createMock(ProcessRunnerInterface::class),
+            $this->createMock(BackupLogger::class),
+            $registry,
+        );
+
+        $storage = new Storage()->setType(Storage::TYPE_RESTIC);
+        $configuration = new BackupConfiguration()
+            ->setName('cfg')
+            ->setSlug('cfg')
+            ->setStorage($storage)
+            ->setType(BackupConfiguration::TYPE_MYSQL);
+        $backup = new Backup()
+            ->setBackupConfiguration($configuration)
+            ->setCreatedAt(new \DateTime('2026-05-16'));
+
+        $source->upload($backup);
+    }
+
+    public function testUploadOnNonResticBackendIsNoop(): void
+    {
+        $registry = $this->createMock(StorageBackendRegistry::class);
+        $registry->method('forStorage')->willReturn(new class implements \App\Backup\Storage\StorageBackendInterface {
+            public function supports(Storage $storage): bool
+            {
+                return true;
+            }
+
+            public function initRepository(Backup $backup): void
+            {
+            }
+
+            public function healthCheck(Backup $backup, bool $tryRepair = true): void
+            {
+            }
+
+            public function prune(Backup $backup): void
+            {
+            }
+        });
+
+        $source = $this->buildSource(
+            $this->createMock(ProcessRunnerInterface::class),
+            $this->createMock(BackupLogger::class),
+            $registry,
+        );
+
+        $storage = new Storage()->setType(Storage::TYPE_RCLONE);
+        $configuration = new BackupConfiguration()
+            ->setName('cfg')
+            ->setSlug('cfg')
+            ->setStorage($storage)
+            ->setType(BackupConfiguration::TYPE_MYSQL);
+        $backup = new Backup()
+            ->setBackupConfiguration($configuration)
+            ->setCreatedAt(new \DateTime('2026-05-16'));
+
+        $source->upload($backup);
+        // Reaching here means the source did not delegate when the backend is wrong.
+        $this->addToAssertionCount(1);
+    }
+
+    private function buildSource(
+        ProcessRunnerInterface $runner,
+        BackupLogger $logger,
+        StorageBackendRegistry $registry,
+    ): DumpSource {
+        return new DumpSource(
+            $runner,
+            $logger,
+            new TemporaryPathResolver(sys_get_temp_dir()),
+            $registry,
+            new SshOptionsBuilder(),
+            new SshKeyMaterializer(),
+        );
+    }
+}

--- a/tests/Backup/Source/OsInstanceSourceTest.php
+++ b/tests/Backup/Source/OsInstanceSourceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Backup\Source;
+
+use App\Backup\Logging\BackupLogger;
+use App\Backup\Path\TemporaryPathResolver;
+use App\Backup\Process\ProcessOutcome;
+use App\Backup\Process\ProcessRunnerInterface;
+use App\Backup\Source\OsInstanceSource;
+use App\Backup\Storage\StorageBackendRegistry;
+use App\Entity\Backup;
+use App\Entity\BackupConfiguration;
+use App\Entity\OSInstance;
+use App\Entity\OSProject;
+use App\Entity\Storage;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+final class OsInstanceSourceTest extends TestCase
+{
+    public function testSupportsOnlyOsInstance(): void
+    {
+        $source = $this->buildSource($this->createMock(ProcessRunnerInterface::class));
+
+        self::assertTrue($source->supports(new BackupConfiguration()->setType(BackupConfiguration::TYPE_OS_INSTANCE)));
+        self::assertFalse($source->supports(new BackupConfiguration()->setType(BackupConfiguration::TYPE_MYSQL)));
+    }
+
+    public function testGetSnapshotStatusReturnsNullWhenImageMissing(): void
+    {
+        $runner = $this->createMock(ProcessRunnerInterface::class);
+        $runner->method('runShell')->willReturn(new ProcessOutcome(true, '[]', '', 0, 'openstack image list'));
+
+        $source = $this->buildSource($runner);
+        $backup = $this->buildBackup();
+
+        self::assertNull($source->getSnapshotStatus($backup));
+    }
+
+    public function testGetSnapshotStatusPersistsAttributesWhenImageFound(): void
+    {
+        $runner = $this->createMock(ProcessRunnerInterface::class);
+        $runner->method('runShell')->willReturn(new ProcessOutcome(
+            true,
+            json_encode([['ID' => 'img-1', 'Checksum' => 'abc', 'Size' => 42, 'Status' => 'active']]),
+            '',
+            0,
+            'openstack image list',
+        ));
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('persist');
+        $em->expects($this->once())->method('flush');
+
+        $source = $this->buildSource($runner, $em);
+        $backup = $this->buildBackup();
+
+        self::assertSame('active', $source->getSnapshotStatus($backup));
+        self::assertSame('img-1', $backup->getOsImageId());
+        self::assertSame('abc', $backup->getChecksum());
+        self::assertSame(42, $backup->getSize());
+    }
+
+    private function buildSource(
+        ProcessRunnerInterface $runner,
+        ?EntityManagerInterface $entityManager = null,
+    ): OsInstanceSource {
+        return new OsInstanceSource(
+            $runner,
+            $this->createMock(BackupLogger::class),
+            new TemporaryPathResolver(sys_get_temp_dir()),
+            $this->createMock(StorageBackendRegistry::class),
+            $entityManager ?? $this->createMock(EntityManagerInterface::class),
+        );
+    }
+
+    private function buildBackup(): Backup
+    {
+        $project = new OSProject()
+            ->setName('proj')
+            ->setSlug('proj');
+        $instance = new OSInstance()
+            ->setName('inst')
+            ->setSlug('inst')
+            ->setId('os-id')
+            ->setOSProject($project);
+
+        $configuration = new BackupConfiguration()
+            ->setName('cfg')
+            ->setSlug('cfg')
+            ->setType(BackupConfiguration::TYPE_OS_INSTANCE)
+            ->setStorage(new Storage()->setType(Storage::TYPE_RESTIC))
+            ->setOsInstance($instance);
+
+        return new Backup()
+            ->setBackupConfiguration($configuration)
+            ->setCreatedAt(new \DateTime('2026-05-16'));
+    }
+}

--- a/tests/Backup/Ssh/SshOptionsBuilderTest.php
+++ b/tests/Backup/Ssh/SshOptionsBuilderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Backup\Ssh;
+
+use App\Backup\Ssh\SshOptionsBuilder;
+use App\Entity\Host;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class SshOptionsBuilderTest extends TestCase
+{
+    public function testReturnsEmptyStringWhenHostIsNull(): void
+    {
+        self::assertSame('', new SshOptionsBuilder()->build(null));
+    }
+
+    public function testReturnsEmptyStringWhenOptionsAreEmpty(): void
+    {
+        $host = new Host()->setSshOptions('');
+
+        self::assertSame('', new SshOptionsBuilder()->build($host));
+    }
+
+    public function testReturnsLeadingSpacePrefixedOptionsWhenValid(): void
+    {
+        $host = new Host()->setSshOptions('-o ConnectTimeout=10');
+
+        self::assertSame(' -o ConnectTimeout=10', new SshOptionsBuilder()->build($host));
+    }
+
+    public function testRejectsInvalidCharactersToPreventInjection(): void
+    {
+        $host = new Host()->setSshOptions('-o ConnectTimeout=10; rm -rf /');
+
+        $this->expectException(InvalidArgumentException::class);
+        new SshOptionsBuilder()->build($host);
+    }
+}

--- a/tests/Backup/Storage/ResticStorageBackendTest.php
+++ b/tests/Backup/Storage/ResticStorageBackendTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Backup\Storage;
+
+use App\Backup\Logging\BackupLogger;
+use App\Backup\Process\ProcessExecutionException;
+use App\Backup\Process\ProcessOutcome;
+use App\Backup\Process\ProcessRunnerInterface;
+use App\Backup\Storage\ResticStorageBackend;
+use App\Entity\Backup;
+use App\Entity\BackupConfiguration;
+use App\Entity\Storage;
+use PHPUnit\Framework\TestCase;
+
+final class ResticStorageBackendTest extends TestCase
+{
+    public function testSupportsReturnsTrueOnlyForResticStorage(): void
+    {
+        $backend = new ResticStorageBackend(
+            $this->createMock(ProcessRunnerInterface::class),
+            $this->createMock(BackupLogger::class),
+        );
+
+        self::assertTrue($backend->supports(new Storage()->setType(Storage::TYPE_RESTIC)));
+        self::assertFalse($backend->supports(new Storage()->setType(Storage::TYPE_RCLONE)));
+        self::assertFalse($backend->supports(new Storage()->setType(Storage::TYPE_KOPIA)));
+    }
+
+    public function testInitRepositoryTreatsAlreadyInitialisedMarkerAsSuccess(): void
+    {
+        $runner = $this->createMock(ProcessRunnerInterface::class);
+        $runner->method('runShell')->willReturn(new ProcessOutcome(
+            successful: false,
+            output: '',
+            errorOutput: 'Fatal: create key in repository repository master key and config already initialized',
+            exitCode: 1,
+            command: 'restic init',
+        ));
+
+        $backend = new ResticStorageBackend($runner, $this->createMock(BackupLogger::class));
+
+        $backend->initRepository($this->buildBackup());
+
+        // No exception means the existing-repo marker was accepted.
+        $this->addToAssertionCount(1);
+    }
+
+    public function testInitRepositoryRethrowsOnGenuineFailure(): void
+    {
+        $runner = $this->createMock(ProcessRunnerInterface::class);
+        $runner->method('runShell')->willReturn(new ProcessOutcome(
+            successful: false,
+            output: '',
+            errorOutput: 'permission denied',
+            exitCode: 1,
+            command: 'restic init',
+        ));
+
+        $backend = new ResticStorageBackend($runner, $this->createMock(BackupLogger::class));
+
+        $this->expectException(ProcessExecutionException::class);
+        $backend->initRepository($this->buildBackup());
+    }
+
+    public function testUploadLocalIssuesResticBackupWithTags(): void
+    {
+        $runner = $this->createMock(ProcessRunnerInterface::class);
+
+        $runner->expects($this->once())
+            ->method('runShell')
+            ->willReturnCallback(function (string $command, array $env, ?int $timeout): ProcessOutcome {
+                self::assertStringContainsString('--tag host="${RESTIC_TAG_VAL_0}"', $command);
+                self::assertStringContainsString('--tag configuration="${RESTIC_TAG_VAL_1}"', $command);
+                self::assertStringContainsString('--host cloudbackup', $command);
+                self::assertSame('the-host', $env['RESTIC_TAG_VAL_0']);
+                self::assertSame('the-config', $env['RESTIC_TAG_VAL_1']);
+                self::assertSame('/tmp/payload', $env['DIRECTORY']);
+                self::assertSame(ResticStorageBackend::UPLOAD_TIMEOUT, $timeout);
+
+                return new ProcessOutcome(true, 'ok', '', 0, $command);
+            });
+
+        $backend = new ResticStorageBackend($runner, $this->createMock(BackupLogger::class));
+        $backend->uploadLocal(
+            $this->buildBackup(),
+            '/tmp/payload',
+            ['host' => 'the-host', 'configuration' => 'the-config'],
+        );
+    }
+
+    public function testPruneRunsForgetWithKeepDailyAndKeepWeekly(): void
+    {
+        $runner = $this->createMock(ProcessRunnerInterface::class);
+
+        $runner->expects($this->once())
+            ->method('runShell')
+            ->willReturnCallback(function (string $command): ProcessOutcome {
+                self::assertStringContainsString('restic forget --prune', $command);
+                self::assertStringContainsString('--keep-daily 7', $command);
+                self::assertStringContainsString('--keep-weekly 4', $command);
+
+                return new ProcessOutcome(true, '', '', 0, $command);
+            });
+
+        $backend = new ResticStorageBackend($runner, $this->createMock(BackupLogger::class));
+        $backup = $this->buildBackup();
+        $backup->getBackupConfiguration()->setKeepDaily(7);
+        $backup->getBackupConfiguration()->setKeepWeekly(4);
+
+        $backend->prune($backup);
+    }
+
+    private function buildBackup(): Backup
+    {
+        $storage = new Storage()
+            ->setType(Storage::TYPE_RESTIC)
+            ->setResticRepo('r')
+            ->setResticPassword('p');
+
+        $configuration = new BackupConfiguration()
+            ->setName('cfg')
+            ->setSlug('cfg')
+            ->setStorage($storage)
+            ->setType(BackupConfiguration::TYPE_MYSQL);
+
+        return new Backup()
+            ->setBackupConfiguration($configuration)
+            ->setCreatedAt(new \DateTime('2026-05-16'));
+    }
+}

--- a/tests/EventSubscriber/BackupSubscriberTest.php
+++ b/tests/EventSubscriber/BackupSubscriberTest.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EventSubscriber;
+
+use App\Backup\Logging\BackupLogger;
+use App\Backup\Source\BackupSourceInterface;
+use App\Backup\Source\BackupSourceRegistry;
+use App\Backup\Storage\ResticStorageBackend;
+use App\Backup\Storage\StorageBackendInterface;
+use App\Backup\Storage\StorageBackendRegistry;
+use App\Entity\Backup;
+use App\Entity\BackupConfiguration;
+use App\Entity\Storage;
+use App\EventSubscriber\BackupSubscriber;
+use App\Repository\BackupRepository;
+use App\Service\MailerService;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Workflow\Event\Event;
+use Symfony\Component\Workflow\Event\GuardEvent;
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\Transition;
+use Symfony\Component\Workflow\WorkflowInterface;
+
+final class BackupSubscriberTest extends TestCase
+{
+    public function testOnStartInitialisesResticRepository(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RESTIC, BackupConfiguration::TYPE_MYSQL);
+        $event = $this->buildEvent($backup);
+
+        $resticBackend = $this->createMock(ResticStorageBackend::class);
+        $resticBackend->expects($this->once())->method('initRepository')->with($backup);
+
+        $storageRegistry = $this->createMock(StorageBackendRegistry::class);
+        $storageRegistry->method('forStorage')->willReturn($resticBackend);
+
+        $this->buildSubscriber(storageRegistry: $storageRegistry)->onStart($event);
+    }
+
+    public function testOnStartIsNoopForRcloneStorage(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RCLONE, BackupConfiguration::TYPE_RCLONE);
+
+        $storageRegistry = $this->createMock(StorageBackendRegistry::class);
+        $storageRegistry->expects($this->never())->method('forStorage');
+
+        $this->buildSubscriber(storageRegistry: $storageRegistry)->onStart($this->buildEvent($backup));
+    }
+
+    public function testOnDownloadDelegatesToSource(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RESTIC, BackupConfiguration::TYPE_MYSQL);
+
+        $source = $this->createMock(BackupSourceInterface::class);
+        $source->expects($this->once())->method('download')->with($backup);
+
+        $sourceRegistry = $this->createMock(BackupSourceRegistry::class);
+        $sourceRegistry->method('forConfiguration')->willReturn($source);
+
+        $this->buildSubscriber(sourceRegistry: $sourceRegistry)->onDownload($this->buildEvent($backup));
+    }
+
+    public function testOnUploadDelegatesToSource(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RESTIC, BackupConfiguration::TYPE_MYSQL);
+
+        $source = $this->createMock(BackupSourceInterface::class);
+        $source->expects($this->once())->method('upload')->with($backup);
+
+        $sourceRegistry = $this->createMock(BackupSourceRegistry::class);
+        $sourceRegistry->method('forConfiguration')->willReturn($source);
+
+        $this->buildSubscriber(sourceRegistry: $sourceRegistry)->onUpload($this->buildEvent($backup));
+    }
+
+    public function testOnHealthCheckDelegatesToStorageBackend(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RESTIC, BackupConfiguration::TYPE_MYSQL);
+
+        $backend = $this->createMock(StorageBackendInterface::class);
+        $backend->expects($this->once())->method('healthCheck')->with($backup, true);
+
+        $registry = $this->createMock(StorageBackendRegistry::class);
+        $registry->method('forStorage')->willReturn($backend);
+
+        $this->buildSubscriber(storageRegistry: $registry)->onHealthCheck($this->buildEvent($backup));
+    }
+
+    public function testOnForgetSkipsResticPruneForReadResticType(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RESTIC, BackupConfiguration::TYPE_READ_RESTIC);
+
+        $registry = $this->createMock(StorageBackendRegistry::class);
+        $registry->expects($this->never())->method('forStorage');
+
+        $this->buildSubscriber(storageRegistry: $registry)->onForget($this->buildEvent($backup));
+    }
+
+    public function testOnForgetRunsResticPruneForResticStorage(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RESTIC, BackupConfiguration::TYPE_MYSQL);
+
+        $backend = $this->createMock(StorageBackendInterface::class);
+        $backend->expects($this->once())->method('prune')->with($backup);
+
+        $registry = $this->createMock(StorageBackendRegistry::class);
+        $registry->method('forStorage')->willReturn($backend);
+
+        $this->buildSubscriber(storageRegistry: $registry)->onForget($this->buildEvent($backup));
+    }
+
+    public function testOnFailedSendsEmailWhenThresholdReached(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RESTIC, BackupConfiguration::TYPE_MYSQL);
+        $backup->getBackupConfiguration()->setNotifyEvery(3);
+
+        $repo = $this->createMock(BackupRepository::class);
+        $repo->method('countFailedBackupsSinceLastSuccess')->willReturn(2);
+
+        $mailer = $this->createMock(MailerService::class);
+        $mailer->expects($this->once())->method('sendFailedBackupReport')->with($backup);
+
+        $this->buildSubscriber(mailer: $mailer, repository: $repo)->onFailed($this->buildEvent($backup));
+    }
+
+    public function testOnFailedSilentWhenNotifyEveryIsZero(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RESTIC, BackupConfiguration::TYPE_MYSQL);
+        $backup->getBackupConfiguration()->setNotifyEvery(0);
+
+        $mailer = $this->createMock(MailerService::class);
+        $mailer->expects($this->never())->method('sendFailedBackupReport');
+
+        $this->buildSubscriber(mailer: $mailer)->onFailed($this->buildEvent($backup));
+    }
+
+    public function testGuardStartBlocksWhenBeforeAllowedHour(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RESTIC, BackupConfiguration::TYPE_MYSQL);
+        $backup->getBackupConfiguration()->setNotBefore(99);
+
+        $guard = $this->buildGuardEvent($backup);
+
+        $this->buildSubscriber()->guardStart($guard);
+
+        self::assertTrue($guard->isBlocked());
+    }
+
+    public function testGuardStartAllowsWhenHourPermits(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RESTIC, BackupConfiguration::TYPE_MYSQL);
+        $backup->getBackupConfiguration()->setNotBefore(0);
+
+        $guard = $this->buildGuardEvent($backup);
+
+        $this->buildSubscriber()->guardStart($guard);
+
+        self::assertFalse($guard->isBlocked());
+    }
+
+    public function testGuardDownloadBlocksWhenSnapshotNotFoundForOsInstance(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RESTIC, BackupConfiguration::TYPE_OS_INSTANCE);
+
+        $source = $this->createMock(BackupSourceInterface::class);
+        $source->method('getSnapshotStatus')->willReturn(null);
+
+        $registry = $this->createMock(BackupSourceRegistry::class);
+        $registry->method('forConfiguration')->willReturn($source);
+
+        $guard = $this->buildGuardEvent($backup);
+        $this->buildSubscriber(sourceRegistry: $registry)->guardDownload($guard);
+
+        self::assertTrue($guard->isBlocked());
+    }
+
+    public function testGuardDownloadAllowsForNonOsInstance(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RESTIC, BackupConfiguration::TYPE_MYSQL);
+
+        $source = $this->createMock(BackupSourceInterface::class);
+        $source->expects($this->never())->method('getSnapshotStatus');
+
+        $registry = $this->createMock(BackupSourceRegistry::class);
+        $registry->method('forConfiguration')->willReturn($source);
+
+        $guard = $this->buildGuardEvent($backup);
+        $this->buildSubscriber(sourceRegistry: $registry)->guardDownload($guard);
+
+        self::assertFalse($guard->isBlocked());
+    }
+
+    public function testGuardDownloadBlocksOnSourceException(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RESTIC, BackupConfiguration::TYPE_OS_INSTANCE);
+
+        $source = $this->createMock(BackupSourceInterface::class);
+        $source->method('getSnapshotStatus')->willThrowException(new Exception('openstack down'));
+
+        $registry = $this->createMock(BackupSourceRegistry::class);
+        $registry->method('forConfiguration')->willReturn($source);
+
+        $guard = $this->buildGuardEvent($backup);
+        $this->buildSubscriber(sourceRegistry: $registry)->guardDownload($guard);
+
+        self::assertTrue($guard->isBlocked());
+    }
+
+    public function testGuardUploadBlocksWhenDownloadIncomplete(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RESTIC, BackupConfiguration::TYPE_MYSQL);
+
+        $source = $this->createMock(BackupSourceInterface::class);
+        $source->method('isDownloadComplete')->willReturn(false);
+
+        $registry = $this->createMock(BackupSourceRegistry::class);
+        $registry->method('forConfiguration')->willReturn($source);
+
+        $guard = $this->buildGuardEvent($backup);
+        $this->buildSubscriber(sourceRegistry: $registry)->guardUpload($guard);
+
+        self::assertTrue($guard->isBlocked());
+    }
+
+    public function testGuardHealthCheckRetriesCleanupWhenNotCleaned(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RESTIC, BackupConfiguration::TYPE_MYSQL);
+
+        $source = $this->createMock(BackupSourceInterface::class);
+        $source->method('isLocallyCleaned')->willReturn(false);
+        $source->expects($this->once())->method('cleanupLocal')->with($backup);
+
+        $registry = $this->createMock(BackupSourceRegistry::class);
+        $registry->method('forConfiguration')->willReturn($source);
+
+        $guard = $this->buildGuardEvent($backup);
+        $this->buildSubscriber(sourceRegistry: $registry)->guardHealthCheck($guard);
+
+        self::assertTrue($guard->isBlocked());
+    }
+
+    public function testGuardForgetRetriesHealthCheckWhenResticSizeMissing(): void
+    {
+        $backup = $this->buildBackup(Storage::TYPE_RESTIC, BackupConfiguration::TYPE_MYSQL);
+        $backup->setResticSize(null);
+
+        $backend = $this->createMock(StorageBackendInterface::class);
+        $backend->expects($this->once())->method('healthCheck')->with($backup, true);
+
+        $registry = $this->createMock(StorageBackendRegistry::class);
+        $registry->method('forStorage')->willReturn($backend);
+
+        $guard = $this->buildGuardEvent($backup);
+        $this->buildSubscriber(storageRegistry: $registry)->guardForget($guard);
+
+        self::assertTrue($guard->isBlocked());
+    }
+
+    public function testSubscribedEventsContainsHealthCheckGuardWithCorrectedSpelling(): void
+    {
+        $events = BackupSubscriber::getSubscribedEvents();
+
+        self::assertSame('guardHealthCheck', $events['workflow.backup.guard.health_check']);
+        self::assertSame('onHealthCheck', $events['workflow.backup.enter.health_check']);
+    }
+
+    private function buildBackup(string $storageType, string $backupType): Backup
+    {
+        $storage = new Storage()->setType($storageType);
+        $configuration = new BackupConfiguration()
+            ->setName('cfg')
+            ->setStorage($storage)
+            ->setType($backupType);
+
+        return new Backup()->setBackupConfiguration($configuration);
+    }
+
+    private function buildEvent(Backup $backup): Event
+    {
+        return new Event(
+            $backup,
+            new Marking([$backup->getCurrentPlace() => 1]),
+            new Transition('upload', 'download', 'upload'),
+            $this->createMock(WorkflowInterface::class),
+        );
+    }
+
+    private function buildGuardEvent(Backup $backup): GuardEvent
+    {
+        return new GuardEvent(
+            $backup,
+            new Marking([$backup->getCurrentPlace() => 1]),
+            new Transition('start', 'initialized', 'start'),
+            $this->createMock(WorkflowInterface::class),
+        );
+    }
+
+    private function buildSubscriber(
+        ?BackupSourceRegistry $sourceRegistry = null,
+        ?StorageBackendRegistry $storageRegistry = null,
+        ?MailerService $mailer = null,
+        ?BackupRepository $repository = null,
+    ): BackupSubscriber {
+        return new BackupSubscriber(
+            $sourceRegistry ?? $this->createMock(BackupSourceRegistry::class),
+            $storageRegistry ?? $this->createMock(StorageBackendRegistry::class),
+            $this->createMock(BackupLogger::class),
+            $mailer ?? $this->createMock(MailerService::class),
+            $repository ?? $this->createMock(BackupRepository::class),
+        );
+    }
+}

--- a/tests/Service/BackupServiceTest.php
+++ b/tests/Service/BackupServiceTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Backup\Logging\BackupLogger;
+use App\Entity\Backup;
+use App\Entity\BackupConfiguration;
+use App\Repository\BackupRepository;
+use App\Service\BackupService;
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\Registry;
+use Symfony\Component\Workflow\WorkflowInterface;
+
+final class BackupServiceTest extends TestCase
+{
+    public function testInitBackupShortCircuitsWhenAlreadyBackupedTodayForDailyPeriodicity(): void
+    {
+        $configuration = new BackupConfiguration()
+            ->setName('cfg')
+            ->setSlug('cfg')
+            ->setPeriodicity(BackupConfiguration::PERIODICITY_DAILY);
+
+        $latest = new Backup()
+            ->setBackupConfiguration($configuration)
+            ->setCurrentPlace('backuped')
+            ->setCreatedAt(new \DateTime());
+
+        $repository = $this->createMock(BackupRepository::class);
+        $repository->method('findOneBy')->willReturn($latest);
+
+        $workflow = $this->createMock(WorkflowInterface::class);
+        $workflow->expects($this->never())->method('apply');
+
+        $registry = $this->createMock(Registry::class);
+        $registry->method('get')->willReturn($workflow);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('persist');
+        $em->expects($this->never())->method('flush');
+
+        new BackupService($em, $registry, $repository, $this->createMock(BackupLogger::class))
+            ->initBackup($configuration);
+    }
+
+    public function testInitBackupCreatesNewBackupWhenNoneExists(): void
+    {
+        $configuration = new BackupConfiguration()
+            ->setName('cfg')
+            ->setSlug('cfg')
+            ->setPeriodicity(BackupConfiguration::PERIODICITY_DAILY);
+
+        $repository = $this->createMock(BackupRepository::class);
+        $repository->method('findOneBy')->willReturn(null);
+
+        $workflow = $this->createMock(WorkflowInterface::class);
+        $workflow->method('can')->willReturnCallback(static fn (Backup $b, string $transition): bool => \in_array($transition, ['start', 'dump'], true));
+
+        $applied = [];
+        $workflow->method('apply')->willReturnCallback(static function (Backup $b, string $transition) use (&$applied): Marking {
+            $applied[] = $transition;
+
+            return new Marking(['initialized' => 1]);
+        });
+
+        $registry = $this->createMock(Registry::class);
+        $registry->method('get')->willReturn($workflow);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        new BackupService($em, $registry, $repository, $this->createMock(BackupLogger::class))
+            ->initBackup($configuration);
+
+        self::assertSame(['start', 'dump'], $applied);
+    }
+
+    public function testInitBackupSilentSkipWhenLatestFailedTodayForDaily(): void
+    {
+        $configuration = new BackupConfiguration()
+            ->setName('cfg')
+            ->setSlug('cfg')
+            ->setPeriodicity(BackupConfiguration::PERIODICITY_DAILY);
+
+        $latest = new Backup()
+            ->setBackupConfiguration($configuration)
+            ->setCurrentPlace('failed')
+            ->setCreatedAt(new \DateTime());
+
+        $repository = $this->createMock(BackupRepository::class);
+        $repository->method('findOneBy')->willReturn($latest);
+
+        $registry = $this->createMock(Registry::class);
+        $registry->expects($this->never())->method('get');
+
+        $logger = $this->createMock(BackupLogger::class);
+        $logger->expects($this->never())->method('log');
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('persist');
+        $em->expects($this->never())->method('flush');
+
+        new BackupService($em, $registry, $repository, $logger)->initBackup($configuration);
+    }
+
+    public function testPerformBackupSilentSkipWhenLatestFailedTodayForDaily(): void
+    {
+        $configuration = new BackupConfiguration()
+            ->setName('cfg')
+            ->setSlug('cfg')
+            ->setPeriodicity(BackupConfiguration::PERIODICITY_DAILY);
+
+        $latest = new Backup()
+            ->setBackupConfiguration($configuration)
+            ->setCurrentPlace('failed')
+            ->setCreatedAt(new \DateTime());
+
+        $repository = $this->createMock(BackupRepository::class);
+        $repository->method('findOneBy')->willReturn($latest);
+
+        $registry = $this->createMock(Registry::class);
+        $registry->expects($this->never())->method('get');
+
+        $logger = $this->createMock(BackupLogger::class);
+        $logger->expects($this->never())->method('log');
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('persist');
+        $em->expects($this->never())->method('flush');
+
+        new BackupService($em, $registry, $repository, $logger)->performBackup($configuration);
+    }
+
+    public function testCompleteBackupSilentSkipWhenLatestFailedTodayForDaily(): void
+    {
+        $configuration = new BackupConfiguration()
+            ->setName('cfg')
+            ->setSlug('cfg')
+            ->setPeriodicity(BackupConfiguration::PERIODICITY_DAILY);
+
+        $latest = new Backup()
+            ->setBackupConfiguration($configuration)
+            ->setCurrentPlace('failed')
+            ->setCreatedAt(new \DateTime());
+
+        $repository = $this->createMock(BackupRepository::class);
+        $repository->method('findOneBy')->willReturn($latest);
+
+        $registry = $this->createMock(Registry::class);
+        $registry->expects($this->never())->method('get');
+
+        $logger = $this->createMock(BackupLogger::class);
+        $logger->expects($this->never())->method('log');
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('persist');
+        $em->expects($this->never())->method('flush');
+
+        new BackupService($em, $registry, $repository, $logger)->completeBackup($configuration);
+    }
+
+    public function testPerformBackupThrowsWhenNoBackupFound(): void
+    {
+        $configuration = new BackupConfiguration()->setName('missing');
+
+        $repository = $this->createMock(BackupRepository::class);
+        $repository->method('findOneBy')->willReturn(null);
+
+        $service = new BackupService(
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(Registry::class),
+            $repository,
+            $this->createMock(BackupLogger::class),
+        );
+
+        $this->expectException(Exception::class);
+        $service->performBackup($configuration);
+    }
+
+    public function testCompleteBackupAppliesEachTransitionInOrder(): void
+    {
+        $configuration = new BackupConfiguration()->setName('cfg')->setSlug('cfg');
+        $backup = new Backup()
+            ->setBackupConfiguration($configuration)
+            ->setCreatedAt(new \DateTime());
+
+        $repository = $this->createMock(BackupRepository::class);
+        $repository->method('findOneBy')->willReturn($backup);
+
+        $workflow = $this->createMock(WorkflowInterface::class);
+        $workflow->method('can')->willReturn(true);
+
+        $applied = [];
+        $workflow->method('apply')->willReturnCallback(static function (Backup $b, string $transition) use (&$applied): Marking {
+            $applied[] = $transition;
+
+            return new Marking([$transition => 1]);
+        });
+
+        $registry = $this->createMock(Registry::class);
+        $registry->method('get')->willReturn($workflow);
+
+        new BackupService(
+            $this->createMock(EntityManagerInterface::class),
+            $registry,
+            $repository,
+            $this->createMock(BackupLogger::class),
+        )->completeBackup($configuration);
+
+        self::assertSame(['health_check', 'forget', 'backuped'], $applied);
+    }
+
+    public function testPerformBackupFailsWorkflowOnException(): void
+    {
+        $configuration = new BackupConfiguration()->setName('cfg')->setSlug('cfg');
+        $backup = new Backup()
+            ->setBackupConfiguration($configuration)
+            ->setCreatedAt(new \DateTime());
+
+        $repository = $this->createMock(BackupRepository::class);
+        $repository->method('findOneBy')->willReturn($backup);
+
+        $applied = [];
+        $workflow = $this->createMock(WorkflowInterface::class);
+        $workflow->method('can')->willReturn(true);
+        $workflow->method('apply')->willReturnCallback(static function (Backup $b, string $transition) use (&$applied): Marking {
+            $applied[] = $transition;
+            if ('upload' === $transition) {
+                throw new Exception('upload exploded');
+            }
+
+            return new Marking([$transition => 1]);
+        });
+
+        $registry = $this->createMock(Registry::class);
+        $registry->method('get')->willReturn($workflow);
+
+        new BackupService(
+            $this->createMock(EntityManagerInterface::class),
+            $registry,
+            $repository,
+            $this->createMock(BackupLogger::class),
+        )->performBackup($configuration);
+
+        self::assertContains('failed', $applied, 'workflow must transition to failed on exception');
+    }
+}


### PR DESCRIPTION
  Split 1743-line BackupService god class into composable strategies
  under src/Backup/. BackupService becomes thin workflow orchestrator
  (initBackup/performBackup/completeBackup); BackupSubscriber dispatches
  to BackupSourceInterface + StorageBackendInterface registries.

  Architecture:
  - Process/: ProcessRunnerInterface + ProcessOutcome + ProcessExecutionException
  - Logging/: BackupLogger (PSR + DB persist)
  - Path/: TemporaryPathResolver
  - Ssh/: SshOptionsBuilder + SshKeyMaterializer with cleanup helper
  - Storage/: Restic / Rclone / Kopia backends + tagged registry
  - Source/: OsInstance / Dump / KubernetesDump / Sftp / Sshfs / Rclone / SshRestic / ReadOnly sources + tagged registry Sources/backends registered via #[AutoconfigureTag], collected via #[AutowireIterator]. No services.yaml entries beyond the temp path parameter binding.

  Behavior fixes shipped with the refactor:
  - Silent skip in initBackup/performBackup/completeBackup when latest backup is in terminal state (failed/backuped) for today on DAILY periodicity — hourly polls no longer spam logs.
  - Temp file leaks closed in 6 paths (private keys + kubeconfigs + scripts
    + rclone configs) via try/finally cleanup.
  - Regex injection of rclone backup dir name (preg_quote).
  - Null private key in SshResticSource now throws clear domain exception instead of writing empty key file.
  - Remote script cleanup failures no longer mask original exec failure.
  - guardHealthCheck / guardForget now contain their own throws so they cannot crash the workflow guard chain.
  - OsInstanceSource.isLocallyCleaned no longer mutates entity + flushes DB; extracted lookupImage() read-only helper.
  - ProcessRunner wraps Symfony Process launch/timeout exceptions in ProcessExecutionException so callers see one error type.
  - BackupSubscriber.guardStart casts date('H') to int + handles null notBefore. "Snaphot" typo corrected.
  - Removed duplicate "Resume backup with current state" log line.

  Renamed guardHealhCheck → guardHealthCheck (workflow event mapping
  updated). Public API surface preserved for BackupStartCommand.

  Tests: 50 new unit tests (108 → 111 total, all green). Mocks
  ProcessRunnerInterface, EntityManager, BackupRepository, Workflow
  Registry. PHPStan clean across src/ + tests/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple backup sources: Kubernetes backups, OS instance snapshots, database dumps, SFTP/SSHFS mounts, and remote backup protocols
  * Added multiple storage backend support: Restic, Rclone, and Kopia storage options
  * Improved backup logging and error tracking with detailed operation history
  * Enhanced SSH-based backup handling with key management and secure authentication

* **Architecture**
  * Refactored backup system to use pluggable source and storage backends for greater flexibility and maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/p-bizouard/CloudBackup/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->